### PR TITLE
feat(#4): expiry resolution + scoring module

### DIFF
--- a/app/providers/yahoo.py
+++ b/app/providers/yahoo.py
@@ -15,7 +15,7 @@ Key implementation notes:
 
 import json
 import logging
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import pandas as pd
@@ -152,6 +152,23 @@ class YahooFinanceProvider(MarketDataProvider, OptionsDataProvider):
             open_interest=cls._safe_int(row.get("openInterest")),
             volume=cls._safe_int(row.get("volume")),
         )
+
+
+def get_settlement_price(symbol: str, expiry_date: str) -> float | None:
+    """Fetch the closing price on the expiry date via yfinance.
+
+    Returns None if no data is available (e.g., market holiday).
+    """
+    try:
+        ticker = yf.Ticker(symbol)
+        expiry = date.fromisoformat(expiry_date)
+        hist = ticker.history(start=expiry.isoformat(), end=(expiry + timedelta(days=1)).isoformat())
+        if hist.empty:
+            return None
+        return float(hist["Close"].iloc[0])
+    except Exception:
+        logger.warning("Failed to fetch settlement price for %s on %s", symbol, expiry_date, exc_info=True)
+        return None
 
 
 # Minimal fallback in case Wikipedia scrape fails.

--- a/app/resolution.py
+++ b/app/resolution.py
@@ -1,0 +1,38 @@
+"""Expiry resolution — resolve expired trades and compute outcomes."""
+
+import sqlite3
+from collections.abc import Callable
+from datetime import date
+
+from app.db import get_unresolved_trades, update_trade_outcome
+from app.scoring import compute_pnl
+
+
+def resolve_expired_trades(
+    conn: sqlite3.Connection,
+    settlement_price_fn: Callable[[str, str], float | None],
+    as_of_date: date | None = None,
+) -> int:
+    """Resolve all expired, unresolved trades.
+
+    Fetches settlement prices via settlement_price_fn(symbol, expiry_date_str),
+    computes outcome and P&L, and updates each trade in the database.
+
+    Returns the number of trades resolved.
+    """
+    if as_of_date is None:
+        as_of_date = date.today()
+
+    trades = get_unresolved_trades(conn, as_of_date)
+    resolved = 0
+
+    for trade in trades:
+        price = settlement_price_fn(trade["symbol"], trade["expiry"])
+        if price is None:
+            continue
+
+        outcome, pnl_pct = compute_pnl(trade["strike"], trade["premium"], price)
+        update_trade_outcome(conn, trade["id"], outcome, price, pnl_pct)
+        resolved += 1
+
+    return resolved

--- a/app/scoring.py
+++ b/app/scoring.py
@@ -1,0 +1,49 @@
+"""Scoring module — pure functions for trade P&L and aggregate statistics."""
+
+
+def compute_pnl(strike: float, premium: float, settlement_price: float) -> tuple[str, float]:
+    """Determine outcome and P&L percentage for a resolved trade.
+
+    Returns (outcome, pnl_pct) where outcome is "OTM" or "ITM".
+    """
+    if settlement_price > strike:
+        return "OTM", premium / strike * 100
+    else:
+        return "ITM", ((settlement_price - strike) + premium) / strike * 100
+
+
+def compute_stats(trades: list[dict]) -> dict:
+    """Compute aggregate statistics from a list of resolved trades.
+
+    Each trade dict must have 'outcome' ("OTM"/"ITM") and 'pnl_pct' keys.
+    """
+    if not trades:
+        return {
+            "hit_rate": None,
+            "avg_return_pct": None,
+            "avg_win_pct": None,
+            "avg_loss_pct": None,
+            "win_loss_ratio": None,
+        }
+
+    wins = [t for t in trades if t["outcome"] == "OTM"]
+    losses = [t for t in trades if t["outcome"] == "ITM"]
+    total = len(trades)
+
+    hit_rate = len(wins) / total * 100
+    avg_return_pct = sum(t["pnl_pct"] for t in trades) / total
+
+    avg_win_pct = sum(t["pnl_pct"] for t in wins) / len(wins) if wins else None
+    avg_loss_pct = sum(t["pnl_pct"] for t in losses) / len(losses) if losses else None
+
+    win_loss_ratio = None
+    if avg_win_pct is not None and avg_loss_pct is not None and avg_loss_pct != 0:
+        win_loss_ratio = abs(avg_win_pct) / abs(avg_loss_pct)
+
+    return {
+        "hit_rate": hit_rate,
+        "avg_return_pct": avg_return_pct,
+        "avg_win_pct": avg_win_pct,
+        "avg_loss_pct": avg_loss_pct,
+        "win_loss_ratio": win_loss_ratio,
+    }

--- a/cron.py
+++ b/cron.py
@@ -8,7 +8,8 @@ import logging
 from app.config import settings
 from app.db import get_connection
 from app.orchestrator import snapshot_daily_trades
-from app.providers.yahoo import YahooFinanceProvider
+from app.providers.yahoo import YahooFinanceProvider, get_settlement_price
+from app.resolution import resolve_expired_trades
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -18,6 +19,9 @@ def main() -> None:
     provider = YahooFinanceProvider()
     conn = get_connection(settings.db_path)
     try:
+        resolved = resolve_expired_trades(conn, get_settlement_price)
+        logger.info("Resolved %d expired trades", resolved)
+
         snapshot_id = snapshot_daily_trades(conn, provider, provider)
         if snapshot_id is None:
             logger.info("Snapshot already exists for today — skipping")

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,0 +1,106 @@
+"""Tests for the expiry resolution module."""
+
+from datetime import date
+
+import pytest
+
+from app.db import get_connection, insert_snapshot, insert_trades
+from app.resolution import resolve_expired_trades
+
+
+@pytest.fixture
+def conn():
+    c = get_connection(":memory:")
+    yield c
+    c.close()
+
+
+SAMPLE_SNAPSHOT = {
+    "snapshot_date": "2026-04-01",
+    "universe_size": 500,
+    "qualified_stocks": 42,
+    "trades_screened": 128,
+    "market_risk_elevated": False,
+    "vix_level": 18.5,
+    "spy_price": 520.0,
+}
+
+SAMPLE_TRADE = {
+    "rank": 1,
+    "symbol": "AAPL",
+    "expiry": "2026-04-03",
+    "strike": 200.0,
+    "premium": 2.50,
+    "pop": 0.82,
+    "delta": -0.18,
+    "theta": -0.05,
+    "implied_volatility": 0.25,
+    "expected_value": 1.80,
+    "days_to_expiry": 14,
+    "support_level": 195.0,
+    "current_price": 215.0,
+    "premium_yield": 0.65,
+    "open_interest": 5000,
+    "safety_score": 0.75,
+    "adjusted_score": 3.15,
+    "next_earnings": "2026-05-01",
+}
+
+
+class TestResolveExpiredTrades:
+    def test_resolves_expired_trades_with_correct_outcome(self, conn):
+        snapshot_id = insert_snapshot(conn, SAMPLE_SNAPSHOT)
+        insert_trades(conn, snapshot_id, [SAMPLE_TRADE])
+
+        # Mock settlement price: 210 > 200 strike → OTM
+        def mock_settlement(symbol, expiry_date):
+            return 210.0
+
+        count = resolve_expired_trades(conn, mock_settlement, as_of_date=date(2026, 4, 4))
+        assert count == 1
+
+        row = conn.execute("SELECT * FROM snapshot_trades WHERE symbol = 'AAPL'").fetchone()
+        assert row["outcome"] == "OTM"
+        assert row["settlement_price"] == 210.0
+        assert row["pnl_pct"] == pytest.approx(1.25)
+
+    def test_skips_trade_when_settlement_price_unavailable(self, conn):
+        snapshot_id = insert_snapshot(conn, SAMPLE_SNAPSHOT)
+        insert_trades(conn, snapshot_id, [SAMPLE_TRADE])
+
+        def mock_settlement(symbol, expiry_date):
+            return None
+
+        count = resolve_expired_trades(conn, mock_settlement, as_of_date=date(2026, 4, 4))
+        assert count == 0
+
+        row = conn.execute("SELECT * FROM snapshot_trades WHERE symbol = 'AAPL'").fetchone()
+        assert row["outcome"] is None
+        assert row["settlement_price"] is None
+
+    def test_no_expired_trades_returns_zero(self, conn):
+        snapshot_id = insert_snapshot(conn, SAMPLE_SNAPSHOT)
+        future_trade = {**SAMPLE_TRADE, "expiry": "2026-04-20"}
+        insert_trades(conn, snapshot_id, [future_trade])
+
+        def mock_settlement(symbol, expiry_date):
+            raise AssertionError("should not be called")
+
+        count = resolve_expired_trades(conn, mock_settlement, as_of_date=date(2026, 4, 4))
+        assert count == 0
+
+    def test_already_resolved_trades_not_re_resolved(self, conn):
+        snapshot_id = insert_snapshot(conn, SAMPLE_SNAPSHOT)
+        insert_trades(conn, snapshot_id, [SAMPLE_TRADE])
+
+        # Resolve it first
+        conn.execute(
+            "UPDATE snapshot_trades SET outcome = 'OTM', settlement_price = 210.0, pnl_pct = 1.25 WHERE symbol = 'AAPL'"
+        )
+        conn.commit()
+
+        def mock_settlement(symbol, expiry_date):
+            raise AssertionError("should not be called for already-resolved trade")
+
+        count = resolve_expired_trades(conn, mock_settlement, as_of_date=date(2026, 4, 4))
+        assert count == 0

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,60 @@
+"""Tests for the scoring module — pure functions, no DB needed."""
+
+import pytest
+
+from app.scoring import compute_pnl, compute_stats
+
+
+class TestComputePnl:
+    def test_otm_trade_returns_premium_yield(self):
+        """settlement_price > strike → OTM, P&L = premium / strike × 100."""
+        outcome, pnl = compute_pnl(strike=200.0, premium=2.50, settlement_price=210.0)
+        assert outcome == "OTM"
+        assert pnl == pytest.approx(1.25)  # 2.50 / 200 × 100
+
+    def test_itm_trade_returns_loss_offset_by_premium(self):
+        """settlement_price <= strike → ITM, P&L = ((settlement - strike) + premium) / strike × 100."""
+        outcome, pnl = compute_pnl(strike=200.0, premium=2.50, settlement_price=195.0)
+        assert outcome == "ITM"
+        assert pnl == pytest.approx(-1.25)  # ((195 - 200) + 2.50) / 200 × 100
+
+    def test_settlement_at_strike_is_itm(self):
+        """Boundary: settlement == strike → ITM (assigned), P&L = premium / strike × 100."""
+        outcome, pnl = compute_pnl(strike=200.0, premium=2.50, settlement_price=200.0)
+        assert outcome == "ITM"
+        assert pnl == pytest.approx(1.25)  # ((200 - 200) + 2.50) / 200 × 100
+
+
+class TestComputeStats:
+    def test_mixed_outcomes(self):
+        trades = [
+            {"outcome": "OTM", "pnl_pct": 1.25},
+            {"outcome": "OTM", "pnl_pct": 0.80},
+            {"outcome": "ITM", "pnl_pct": -2.50},
+        ]
+        stats = compute_stats(trades)
+        assert stats["hit_rate"] == pytest.approx(200 / 3)  # 2 wins out of 3
+        assert stats["avg_return_pct"] == pytest.approx((1.25 + 0.80 - 2.50) / 3)
+        assert stats["avg_win_pct"] == pytest.approx((1.25 + 0.80) / 2)
+        assert stats["avg_loss_pct"] == pytest.approx(-2.50)
+        assert stats["win_loss_ratio"] == pytest.approx((1.25 + 0.80) / 2 / 2.50)
+
+    def test_empty_list_returns_all_none(self):
+        stats = compute_stats([])
+        assert stats["hit_rate"] is None
+        assert stats["avg_return_pct"] is None
+        assert stats["avg_win_pct"] is None
+        assert stats["avg_loss_pct"] is None
+        assert stats["win_loss_ratio"] is None
+
+    def test_all_wins_no_losses(self):
+        trades = [
+            {"outcome": "OTM", "pnl_pct": 1.25},
+            {"outcome": "OTM", "pnl_pct": 0.80},
+        ]
+        stats = compute_stats(trades)
+        assert stats["hit_rate"] == pytest.approx(100.0)
+        assert stats["avg_return_pct"] == pytest.approx((1.25 + 0.80) / 2)
+        assert stats["avg_win_pct"] == pytest.approx((1.25 + 0.80) / 2)
+        assert stats["avg_loss_pct"] is None
+        assert stats["win_loss_ratio"] is None


### PR DESCRIPTION
## Summary
- Adds `app/scoring.py` with pure functions for OTM/ITM determination, P&L calculation, and aggregate statistics (hit_rate, avg_return, avg_win, avg_loss, win_loss_ratio)
- Adds `app/resolution.py` with `resolve_expired_trades()` that fetches settlement prices via an injectable callable, computes outcomes, and updates the DB
- Adds `get_settlement_price()` to `app/providers/yahoo.py` for yfinance closing price lookup
- Updates `cron.py` to run resolution before daily snapshot

## Test plan
- [x] OTM trade returns correct P&L (`premium / strike × 100`)
- [x] ITM trade returns correct P&L (`((settlement - strike) + premium) / strike × 100`)
- [x] Settlement exactly at strike → ITM
- [x] `compute_stats` with mixed OTM/ITM → correct aggregates
- [x] `compute_stats` with empty list → all None
- [x] `compute_stats` with all wins → avg_loss and win_loss_ratio are None
- [x] Resolves expired trades with correct outcome and DB update
- [x] Skips trades when settlement price unavailable
- [x] No expired trades → returns 0, no DB writes
- [x] Already-resolved trades not re-resolved

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)