### PR TITLE
feat(#5): report API endpoints

### DIFF
--- a/app/models/report.py
+++ b/app/models/report.py
@@ -1,0 +1,48 @@
+"""Pydantic models for the backtesting report API."""
+
+from pydantic import BaseModel
+
+
+class SummaryResponse(BaseModel):
+    total_tracked: int
+    total_resolved: int
+    total_active: int
+    hit_rate: float | None
+    avg_return_pct: float | None
+    avg_win_pct: float | None
+    avg_loss_pct: float | None
+    win_loss_ratio: float | None
+    date_range_start: str | None
+    date_range_end: str | None
+
+
+class TradeItem(BaseModel):
+    id: int
+    snapshot_id: int
+    snapshot_date: str
+    rank: int
+    symbol: str
+    expiry: str
+    strike: float
+    premium: float
+    pop: float
+    delta: float
+    theta: float | None
+    implied_volatility: float
+    expected_value: float
+    days_to_expiry: int
+    support_level: float
+    current_price: float
+    premium_yield: float
+    open_interest: int
+    safety_score: float | None
+    adjusted_score: float | None
+    next_earnings: str | None
+    outcome: str | None
+    settlement_price: float | None
+    pnl_pct: float | None
+    days_remaining: int | None
+
+
+class TradesResponse(BaseModel):
+    trades: list[TradeItem]

--- a/app/server.py
+++ b/app/server.py
@@ -5,16 +5,19 @@ For local development, run: uvicorn app.server:app --reload
 """
 
 import threading
+from datetime import date
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.db import get_connection, get_summary_stats, get_trades_by_status
 from app.engine.market_risk import assess_market_risk
 from app.engine.pipeline import run_scan
 from app.engine.universe import filter_universe
 from app.models.market import MarketRiskStatus
 from app.models.option import ScanResult
+from app.models.report import SummaryResponse, TradeItem, TradesResponse
 from app.models.stock import UniverseFilterResult
 from app.providers.news import FinnhubNewsProvider
 from app.providers.yahoo import YahooFinanceProvider
@@ -153,3 +156,38 @@ def _coalesced_scan(max_trades: int | None = None) -> ScanResult:
 def get_market_status() -> MarketRiskStatus:
     """Get current market risk indicators (VIX + SPY trend)."""
     return assess_market_risk(_yahoo)
+
+
+# ---------------------------------------------------------------------------
+# Report endpoints — backtesting data
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/report/summary", response_model=SummaryResponse)
+def get_report_summary() -> SummaryResponse:
+    """Return aggregate backtesting statistics."""
+    conn = get_connection(settings.db_path)
+    try:
+        stats = get_summary_stats(conn)
+        return SummaryResponse(**stats)
+    finally:
+        conn.close()
+
+
+@app.get("/api/report/trades", response_model=TradesResponse)
+def get_report_trades(status: str = "all") -> TradesResponse:
+    """Return trade list filtered by status with computed fields."""
+    conn = get_connection(settings.db_path)
+    try:
+        rows = get_trades_by_status(conn, status)
+        today = date.today()
+        trades = []
+        for row in rows:
+            days_remaining = None
+            if row.get("outcome") is None:
+                expiry = date.fromisoformat(row["expiry"])
+                days_remaining = max((expiry - today).days, 0)
+            trades.append(TradeItem(**row, days_remaining=days_remaining))
+        return TradesResponse(trades=trades)
+    finally:
+        conn.close()

--- a/tests/test_report_api.py
+++ b/tests/test_report_api.py
@@ -1,0 +1,161 @@
+"""Tests for the report API endpoints."""
+
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_connection, insert_snapshot, insert_trades, update_trade_outcome
+
+
+SAMPLE_SNAPSHOT = {
+    "snapshot_date": "2026-04-01",
+    "universe_size": 500,
+    "qualified_stocks": 42,
+    "trades_screened": 128,
+    "market_risk_elevated": False,
+    "vix_level": 18.5,
+    "spy_price": 520.0,
+}
+
+SAMPLE_TRADE = {
+    "rank": 1,
+    "symbol": "AAPL",
+    "expiry": "2026-04-18",
+    "strike": 200.0,
+    "premium": 2.50,
+    "pop": 0.82,
+    "delta": -0.18,
+    "theta": -0.05,
+    "implied_volatility": 0.25,
+    "expected_value": 1.80,
+    "days_to_expiry": 14,
+    "support_level": 195.0,
+    "current_price": 215.0,
+    "premium_yield": 0.65,
+    "open_interest": 5000,
+    "safety_score": 0.75,
+    "adjusted_score": 3.15,
+    "next_earnings": "2026-05-01",
+}
+
+
+@pytest.fixture
+def conn():
+    import sqlite3
+    from app.db import _create_schema
+
+    c = sqlite3.connect(":memory:", check_same_thread=False)
+    c.row_factory = sqlite3.Row
+    _create_schema(c)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def client(conn):
+    with patch("app.server.get_connection", return_value=conn):
+        from app.server import app
+        yield TestClient(app)
+
+
+def _seed_mixed_trades(conn):
+    """Insert one resolved OTM, one resolved ITM, and one active trade."""
+    snap_id = insert_snapshot(conn, SAMPLE_SNAPSHOT)
+    snap2_id = insert_snapshot(conn, {**SAMPLE_SNAPSHOT, "snapshot_date": "2026-04-04"})
+
+    win = {**SAMPLE_TRADE, "expiry": "2026-04-01"}
+    loss = {**SAMPLE_TRADE, "rank": 2, "symbol": "MSFT", "expiry": "2026-04-01"}
+    active = {**SAMPLE_TRADE, "rank": 3, "symbol": "GOOG", "expiry": "2026-04-25"}
+    insert_trades(conn, snap_id, [win, loss])
+    insert_trades(conn, snap2_id, [active])
+
+    trades = conn.execute(
+        "SELECT id, symbol FROM snapshot_trades WHERE expiry = '2026-04-01'"
+    ).fetchall()
+    for t in trades:
+        if t["symbol"] == "AAPL":
+            update_trade_outcome(conn, t["id"], "OTM", 210.0, 1.25)
+        else:
+            update_trade_outcome(conn, t["id"], "ITM", 195.0, -1.25)
+
+
+class TestReportSummary:
+    def test_summary_with_data(self, client, conn):
+        _seed_mixed_trades(conn)
+        resp = client.get("/api/report/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_tracked"] == 3
+        assert data["total_resolved"] == 2
+        assert data["total_active"] == 1
+        assert data["hit_rate"] == 50.0
+        assert data["date_range_start"] == "2026-04-01"
+        assert data["date_range_end"] == "2026-04-04"
+
+    def test_summary_empty_state(self, client):
+        resp = client.get("/api/report/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_tracked"] == 0
+        assert data["total_resolved"] == 0
+        assert data["total_active"] == 0
+        assert data["hit_rate"] is None
+        assert data["avg_return_pct"] is None
+        assert data["date_range_start"] is None
+
+
+class TestReportTrades:
+    def test_filter_active(self, client, conn):
+        _seed_mixed_trades(conn)
+        resp = client.get("/api/report/trades?status=active")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["trades"]) == 1
+        assert data["trades"][0]["symbol"] == "GOOG"
+        assert data["trades"][0]["outcome"] is None
+
+    def test_filter_resolved(self, client, conn):
+        _seed_mixed_trades(conn)
+        resp = client.get("/api/report/trades?status=resolved")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["trades"]) == 2
+        symbols = {t["symbol"] for t in data["trades"]}
+        assert symbols == {"AAPL", "MSFT"}
+
+    def test_filter_all(self, client, conn):
+        _seed_mixed_trades(conn)
+        resp = client.get("/api/report/trades?status=all")
+        assert resp.status_code == 200
+        assert len(resp.json()["trades"]) == 3
+
+    def test_active_trade_has_days_remaining(self, client, conn):
+        _seed_mixed_trades(conn)
+        mock_date = type("FakeDate", (), {
+            "today": staticmethod(lambda: date(2026, 4, 10)),
+            "fromisoformat": staticmethod(date.fromisoformat),
+        })
+        with patch("app.server.date", mock_date):
+            resp = client.get("/api/report/trades?status=active")
+        trade = resp.json()["trades"][0]
+        # GOOG expiry is 2026-04-25, today is 2026-04-10 → 15 days remaining
+        assert trade["days_remaining"] == 15
+
+    def test_resolved_trade_has_no_days_remaining(self, client, conn):
+        _seed_mixed_trades(conn)
+        resp = client.get("/api/report/trades?status=resolved")
+        for trade in resp.json()["trades"]:
+            assert trade["days_remaining"] is None
+
+    def test_empty_state(self, client):
+        resp = client.get("/api/report/trades")
+        assert resp.status_code == 200
+        assert resp.json()["trades"] == []
+
+    def test_defaults_to_all(self, client, conn):
+        _seed_mixed_trades(conn)
+        resp = client.get("/api/report/trades")
+        assert resp.status_code == 200
+        assert len(resp.json()["trades"]) == 3


### PR DESCRIPTION
## Summary
- Adds `GET /api/report/summary` endpoint returning aggregate backtesting stats (hit rate, avg return, win/loss ratio, date range, etc.)
- Adds `GET /api/report/trades?status=active|resolved|all` endpoint returning filtered trade list with computed fields (`days_remaining` for active trades)
- Pydantic response models defined in `app/models/report.py`

## Test plan
- [x] Summary endpoint returns correct aggregate stats from populated DB
- [x] Summary endpoint returns zero-state gracefully when DB is empty
- [x] Trades endpoint filters by active/resolved/all status
- [x] Active trades include computed `days_remaining` field
- [x] Resolved trades have `days_remaining` as null
- [x] Trades endpoint returns empty list when no data exists
- [x] Status query param defaults to `all`
- [x] Full test suite passes (115 tests)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)