### PR TITLE
feat(#6): frontend report view

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,11 +9,15 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^7.14.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -22,11 +26,81 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.0.1",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.2"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.5.tgz",
+      "integrity": "sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.6.tgz",
+      "integrity": "sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -220,6 +294,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -266,6 +350,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -457,6 +694,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -850,6 +1105,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1122,6 +1384,96 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1132,6 +1484,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1498,6 +1876,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1538,6 +2029,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1561,6 +2063,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1579,6 +2101,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1657,6 +2189,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1708,6 +2250,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1723,12 +2278,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1748,12 +2338,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1764,6 +2371,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.321",
@@ -1785,6 +2400,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1983,6 +2618,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1991,6 +2636,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2168,6 +2823,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2205,6 +2873,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2227,6 +2905,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2263,6 +2948,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2630,6 +3366,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2638,6 +3385,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2691,6 +3455,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2756,6 +3531,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2775,6 +3563,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2835,6 +3630,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2864,6 +3689,76 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-router": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2917,6 +3812,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2932,6 +3840,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2956,6 +3870,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2964,6 +3885,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2992,6 +3940,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -3013,6 +3968,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3028,6 +4000,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3100,6 +4128,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3228,6 +4266,136 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3244,6 +4412,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3253,6 +4438,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,15 +7,21 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -24,9 +30,11 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.0.1",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.2"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,92 +1,16 @@
-import { useState, useEffect } from 'react'
+import { Routes, Route } from 'react-router-dom'
 import AppHeader from './components/AppHeader'
-import ControlBar from './components/ControlBar'
-import FilterPanel, { DEFAULT_FILTERS, type Filters } from './components/FilterPanel'
-import Legend from './components/Legend'
-import RiskDashboard from './components/RiskDashboard'
-import TradeTable from './components/TradeTable'
-import { useTrades, useMarketStatus } from './hooks/useTrades'
+import ScreenerPage from './pages/ScreenerPage'
+import ReportPage from './pages/ReportPage'
 
 function App() {
-  const [capital, setCapital] = useState(() => {
-    const saved = localStorage.getItem('capital')
-    return saved ? Number(saved) : 50000
-  })
-  const [margin, setMargin] = useState(() => {
-    const saved = localStorage.getItem('margin')
-    return saved ? Number(saved) : 0.3
-  })
-  const [filterOpen, setFilterOpen] = useState(false)
-  const [riskOpen, setRiskOpen] = useState(false)
-  const [legendOpen, setLegendOpen] = useState(false)
-  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS)
-
-  const { scanResult, loading, error, runScan } = useTrades()
-  const { status: marketStatus, loading: marketLoading, refresh: refreshMarket } = useMarketStatus()
-
-  useEffect(() => {
-    localStorage.setItem('capital', String(capital))
-  }, [capital])
-
-  useEffect(() => {
-    localStorage.setItem('margin', String(margin))
-  }, [margin])
-
   return (
     <div className="min-h-screen flex flex-col">
-      <AppHeader
-        capital={capital}
-        margin={margin}
-        onCapitalChange={setCapital}
-        onMarginChange={setMargin}
-      />
-
-      <ControlBar
-        onScan={() => runScan()}
-        onToggleFilter={() => setFilterOpen(!filterOpen)}
-        onToggleRisk={() => setRiskOpen(!riskOpen)}
-        onToggleLegend={() => setLegendOpen(!legendOpen)}
-        loading={loading}
-        filterOpen={filterOpen}
-        legendOpen={legendOpen}
-      />
-
-      {riskOpen && (
-        <RiskDashboard
-          status={marketStatus}
-          loading={marketLoading}
-          onRefresh={refreshMarket}
-          onClose={() => setRiskOpen(false)}
-        />
-      )}
-
-      {legendOpen && (
-        <Legend onClose={() => setLegendOpen(false)} />
-      )}
-
-      {filterOpen && (
-        <FilterPanel filters={filters} onChange={setFilters} />
-      )}
-
-      {error && (
-        <div className="px-4 py-2 bg-terminal-red/10 border-b border-terminal-red/30 text-terminal-red text-sm">
-          {error}
-        </div>
-      )}
-
-      {scanResult && (
-        <div className="px-4 py-2 border-b border-terminal-border text-xs text-terminal-muted flex gap-4">
-          <span>Universe: {scanResult.universe_size}</span>
-          <span>Qualified: {scanResult.qualified_stocks}</span>
-          <span>Trades: {scanResult.trades_screened}</span>
-          <span>Scanned: {scanResult.scan_timestamp}</span>
-        </div>
-      )}
-
-      <TradeTable
-        trades={scanResult?.trades ?? []}
-        filters={filters}
-      />
+      <AppHeader />
+      <Routes>
+        <Route path="/" element={<ScreenerPage />} />
+        <Route path="/report" element={<ReportPage />} />
+      </Routes>
     </div>
   )
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ScanResult, MarketRiskStatus } from '../types'
+import type { ScanResult, MarketRiskStatus, SummaryResponse, TradesResponse } from '../types'
 
 // In dev: empty string → Vite proxy handles /api → localhost:8000
 // In prod: VITE_API_URL points to the Railway backend (e.g. https://my-app.up.railway.app/api)
@@ -20,5 +20,17 @@ export async function fetchTrades(
 export async function fetchMarketStatus(): Promise<MarketRiskStatus> {
   const resp = await fetch(`${BASE}/market-status`)
   if (!resp.ok) throw new Error(`Failed to fetch market status: ${resp.status}`)
+  return resp.json()
+}
+
+export async function fetchReportSummary(): Promise<SummaryResponse> {
+  const resp = await fetch(`${BASE}/report/summary`)
+  if (!resp.ok) throw new Error(`Failed to fetch report summary: ${resp.status}`)
+  return resp.json()
+}
+
+export async function fetchReportTrades(status: string = 'all'): Promise<TradesResponse> {
+  const resp = await fetch(`${BASE}/report/trades?status=${status}`)
+  if (!resp.ok) throw new Error(`Failed to fetch report trades: ${resp.status}`)
   return resp.json()
 }

--- a/frontend/src/components/ActiveTradesTable.tsx
+++ b/frontend/src/components/ActiveTradesTable.tsx
@@ -1,0 +1,59 @@
+import type { ReportTradeItem } from '../types'
+
+interface Props {
+  trades: ReportTradeItem[]
+  onRefresh?: () => void
+}
+
+export default function ActiveTradesTable({ trades, onRefresh }: Props) {
+  if (trades.length === 0) {
+    return (
+      <div className="text-terminal-muted text-sm py-4 text-center">
+        No active trades.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      {onRefresh && (
+        <div className="mb-2">
+          <button
+            onClick={onRefresh}
+            className="px-3 py-1 bg-terminal-cyan/20 text-terminal-cyan border border-terminal-cyan/30 rounded text-sm hover:bg-terminal-cyan/30 transition-colors"
+          >
+            Refresh Prices
+          </button>
+        </div>
+      )}
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-terminal-border text-terminal-muted text-xs text-left">
+            <th className="px-3 py-2">Symbol</th>
+            <th className="px-3 py-2">Expiry</th>
+            <th className="px-3 py-2">Strike</th>
+            <th className="px-3 py-2">Price</th>
+            <th className="px-3 py-2">Premium</th>
+            <th className="px-3 py-2">POP</th>
+            <th className="px-3 py-2">DTE</th>
+            <th className="px-3 py-2">Safety</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trades.map((t) => (
+            <tr key={t.id} className="border-b border-terminal-border/50 hover:bg-terminal-surface/50">
+              <td className="px-3 py-2 font-bold text-terminal-cyan">{t.symbol}</td>
+              <td className="px-3 py-2">{t.expiry}</td>
+              <td className="px-3 py-2">{t.strike}</td>
+              <td className="px-3 py-2">{t.current_price}</td>
+              <td className="px-3 py-2">${t.premium.toFixed(2)}</td>
+              <td className="px-3 py-2">{(t.pop * 100).toFixed(0)}%</td>
+              <td className="px-3 py-2">{t.days_remaining !== null ? `${t.days_remaining}d` : '—'}</td>
+              <td className="px-3 py-2">{t.safety_score !== null ? t.safety_score.toFixed(0) : '—'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,14 +1,12 @@
-import { useState } from 'react'
+import { NavLink } from 'react-router-dom'
 
-interface Props {
-  capital: number
-  margin: number
-  onCapitalChange: (v: number) => void
-  onMarginChange: (v: number) => void
-}
-
-export default function AppHeader({ capital, margin, onCapitalChange, onMarginChange }: Props) {
-  const [editing, setEditing] = useState(false)
+export default function AppHeader() {
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `px-3 py-1 rounded text-sm transition-colors ${
+      isActive
+        ? 'bg-terminal-green/20 text-terminal-green'
+        : 'text-terminal-muted hover:text-terminal-text'
+    }`
 
   return (
     <header className="border-b border-terminal-border bg-terminal-surface px-4 py-3 flex items-center justify-between">
@@ -17,44 +15,14 @@ export default function AppHeader({ capital, margin, onCapitalChange, onMarginCh
         <h1 className="text-base font-bold tracking-tight">OptionTerminal</h1>
       </div>
 
-      <div className="flex items-center gap-4 text-sm text-terminal-muted">
-        {editing ? (
-          <div className="flex items-center gap-2">
-            <label>
-              Capital:
-              <input
-                type="number"
-                value={capital}
-                onChange={(e) => onCapitalChange(Number(e.target.value))}
-                className="ml-1 w-24 bg-terminal-bg border border-terminal-border rounded px-2 py-0.5 text-terminal-text text-sm"
-              />
-            </label>
-            <label>
-              Margin:
-              <input
-                type="number"
-                value={Math.round(margin * 100)}
-                onChange={(e) => onMarginChange(Number(e.target.value) / 100)}
-                className="ml-1 w-16 bg-terminal-bg border border-terminal-border rounded px-2 py-0.5 text-terminal-text text-sm"
-              />%
-            </label>
-            <button
-              onClick={() => setEditing(false)}
-              className="text-terminal-green hover:text-terminal-text"
-            >
-              Done
-            </button>
-          </div>
-        ) : (
-          <button
-            onClick={() => setEditing(true)}
-            className="flex items-center gap-3 hover:text-terminal-text transition-colors"
-          >
-            <span>Capital: <span className="text-terminal-text">${capital.toLocaleString()}</span></span>
-            <span>Margin: <span className="text-terminal-text">{Math.round(margin * 100)}%</span></span>
-          </button>
-        )}
-      </div>
+      <nav className="flex items-center gap-2">
+        <NavLink to="/" className={linkClass} end>
+          Screener
+        </NavLink>
+        <NavLink to="/report" className={linkClass}>
+          Report
+        </NavLink>
+      </nav>
     </header>
   )
 }

--- a/frontend/src/components/CapitalSettings.tsx
+++ b/frontend/src/components/CapitalSettings.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+
+interface Props {
+  capital: number
+  margin: number
+  onCapitalChange: (v: number) => void
+  onMarginChange: (v: number) => void
+}
+
+export default function CapitalSettings({ capital, margin, onCapitalChange, onMarginChange }: Props) {
+  const [editing, setEditing] = useState(false)
+
+  return (
+    <div className="border-b border-terminal-border bg-terminal-surface px-4 py-2 flex items-center gap-4 text-sm text-terminal-muted">
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <label>
+            Capital:
+            <input
+              type="number"
+              value={capital}
+              onChange={(e) => onCapitalChange(Number(e.target.value))}
+              className="ml-1 w-24 bg-terminal-bg border border-terminal-border rounded px-2 py-0.5 text-terminal-text text-sm"
+            />
+          </label>
+          <label>
+            Margin:
+            <input
+              type="number"
+              value={Math.round(margin * 100)}
+              onChange={(e) => onMarginChange(Number(e.target.value) / 100)}
+              className="ml-1 w-16 bg-terminal-bg border border-terminal-border rounded px-2 py-0.5 text-terminal-text text-sm"
+            />%
+          </label>
+          <button
+            onClick={() => setEditing(false)}
+            className="text-terminal-green hover:text-terminal-text"
+          >
+            Done
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setEditing(true)}
+          className="flex items-center gap-3 hover:text-terminal-text transition-colors"
+        >
+          <span>Capital: <span className="text-terminal-text">${capital.toLocaleString()}</span></span>
+          <span>Margin: <span className="text-terminal-text">{Math.round(margin * 100)}%</span></span>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/MethodologyPanel.tsx
+++ b/frontend/src/components/MethodologyPanel.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react'
+
+export default function MethodologyPanel() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <section className="mt-6">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 text-sm font-bold text-terminal-muted hover:text-terminal-text transition-colors"
+      >
+        <span>{open ? '▾' : '▸'}</span>
+        Methodology
+      </button>
+
+      {open && (
+        <div className="mt-3 bg-terminal-surface border border-terminal-border rounded p-4 text-sm space-y-4">
+          <div>
+            <h3 className="font-bold text-terminal-cyan mb-1">Outcome Determination</h3>
+            <p className="text-terminal-muted">
+              Each trade is resolved at expiry. The settlement price is compared to the strike price
+              to determine the outcome.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-bold text-terminal-cyan mb-1">OTM (Out of the Money)</h3>
+            <p className="text-terminal-muted">
+              A put option expires OTM when the underlying stock price is above the strike price at expiry.
+              This is a winning trade — the seller keeps the full premium.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-bold text-terminal-cyan mb-1">ITM (In the Money)</h3>
+            <p className="text-terminal-muted">
+              A put option expires ITM when the underlying stock price is below the strike price at expiry.
+              The seller is assigned shares and incurs a loss equal to (strike − settlement price − premium received).
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-bold text-terminal-cyan mb-1">P&L Calculation</h3>
+            <p className="text-terminal-muted">
+              For OTM trades: P&L % = premium / (strike × margin requirement) × 100.
+              For ITM trades: P&L % = (premium − (strike − settlement price)) / (strike × margin requirement) × 100.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-bold text-terminal-cyan mb-1">Hit Rate</h3>
+            <p className="text-terminal-muted">
+              Percentage of resolved trades that expired OTM (profitable). Hit rate = OTM trades / total resolved trades.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-bold text-terminal-cyan mb-1">Timing Assumptions</h3>
+            <p className="text-terminal-muted">
+              Trades are tracked from the daily snapshot. Resolution uses next-day closing prices after expiry.
+              Settlement prices are fetched from market data on the first trading day after expiration.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-bold text-terminal-cyan mb-1">Scoring</h3>
+            <p className="text-terminal-muted">
+              Safety Score combines POP, delta, support proximity, and implied volatility.
+              Adjusted Score applies time-decay and earnings proximity adjustments.
+            </p>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/ResolvedTradesTable.tsx
+++ b/frontend/src/components/ResolvedTradesTable.tsx
@@ -1,0 +1,58 @@
+import type { ReportTradeItem } from '../types'
+
+interface Props {
+  trades: ReportTradeItem[]
+}
+
+function formatPnl(pnl: number | null): string {
+  if (pnl === null) return '—'
+  const sign = pnl >= 0 ? '+' : ''
+  return `${sign}${pnl.toFixed(2)}%`
+}
+
+export default function ResolvedTradesTable({ trades }: Props) {
+  if (trades.length === 0) {
+    return (
+      <div className="text-terminal-muted text-sm py-4 text-center">
+        No resolved trades.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-terminal-border text-terminal-muted text-xs text-left">
+            <th className="px-3 py-2">Symbol</th>
+            <th className="px-3 py-2">Expiry</th>
+            <th className="px-3 py-2">Strike</th>
+            <th className="px-3 py-2">Settlement</th>
+            <th className="px-3 py-2">Outcome</th>
+            <th className="px-3 py-2">P&L</th>
+            <th className="px-3 py-2">Premium</th>
+            <th className="px-3 py-2">Safety</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trades.map((t) => (
+            <tr key={t.id} className="border-b border-terminal-border/50 hover:bg-terminal-surface/50">
+              <td className="px-3 py-2 font-bold text-terminal-cyan">{t.symbol}</td>
+              <td className="px-3 py-2">{t.expiry}</td>
+              <td className="px-3 py-2">{t.strike}</td>
+              <td className="px-3 py-2">{t.settlement_price !== null ? t.settlement_price : '—'}</td>
+              <td className={`px-3 py-2 font-bold ${t.outcome === 'OTM' ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                {t.outcome}
+              </td>
+              <td className={`px-3 py-2 ${(t.pnl_pct ?? 0) >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                {formatPnl(t.pnl_pct)}
+              </td>
+              <td className="px-3 py-2">${t.premium.toFixed(2)}</td>
+              <td className="px-3 py-2">{t.safety_score !== null ? t.safety_score.toFixed(0) : '—'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/StatusFilter.tsx
+++ b/frontend/src/components/StatusFilter.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  value: string
+  onChange: (status: string) => void
+}
+
+const OPTIONS = ['all', 'active', 'resolved'] as const
+
+export default function StatusFilter({ value, onChange }: Props) {
+  return (
+    <div className="flex gap-1">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt}
+          onClick={() => onChange(opt)}
+          className={`px-3 py-1 rounded text-sm capitalize transition-colors ${
+            value === opt
+              ? 'bg-terminal-cyan/20 text-terminal-cyan border border-terminal-cyan/30'
+              : 'text-terminal-muted hover:text-terminal-text border border-terminal-border'
+          }`}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/SummaryCards.tsx
+++ b/frontend/src/components/SummaryCards.tsx
@@ -12,7 +12,7 @@ function formatPct(val: number | null): string {
 
 function formatHitRate(val: number | null): string {
   if (val === null) return '—'
-  return `${(val * 100).toFixed(1)}%`
+  return `${val.toFixed(1)}%`
 }
 
 function formatRatio(val: number | null): string {

--- a/frontend/src/components/SummaryCards.tsx
+++ b/frontend/src/components/SummaryCards.tsx
@@ -1,0 +1,68 @@
+import Tooltip from './Tooltip'
+import type { SummaryResponse } from '../types'
+
+interface Props {
+  summary: SummaryResponse
+}
+
+function formatPct(val: number | null): string {
+  if (val === null) return '—'
+  return `${val.toFixed(2)}%`
+}
+
+function formatHitRate(val: number | null): string {
+  if (val === null) return '—'
+  return `${(val * 100).toFixed(1)}%`
+}
+
+function formatRatio(val: number | null): string {
+  if (val === null) return '—'
+  return val.toFixed(2)
+}
+
+const TOOLTIPS: Record<string, string> = {
+  'Total Tracked': 'Total number of trades captured by daily snapshots',
+  'Resolved': 'Trades that have reached expiry and been settled',
+  'Active': 'Trades awaiting expiry, still being tracked',
+  'Hit Rate': 'Percentage of resolved trades that expired OTM (profitable)',
+  'Avg Return': 'Average P&L percentage across all resolved trades',
+  'Avg Win': 'Average P&L percentage for winning (OTM) trades',
+  'Avg Loss': 'Average P&L percentage for losing (ITM) trades',
+  'Win/Loss Ratio': 'Ratio of average win size to average loss size',
+}
+
+export default function SummaryCards({ summary }: Props) {
+  const cards = [
+    { label: 'Total Tracked', value: String(summary.total_tracked) },
+    { label: 'Resolved', value: String(summary.total_resolved) },
+    { label: 'Active', value: String(summary.total_active) },
+    { label: 'Hit Rate', value: formatHitRate(summary.hit_rate) },
+    { label: 'Avg Return', value: formatPct(summary.avg_return_pct) },
+    { label: 'Avg Win', value: formatPct(summary.avg_win_pct) },
+    { label: 'Avg Loss', value: formatPct(summary.avg_loss_pct) },
+    { label: 'Win/Loss Ratio', value: formatRatio(summary.win_loss_ratio) },
+  ]
+
+  return (
+    <div>
+      <div className="grid grid-cols-4 gap-3 mb-4">
+        {cards.map((c) => (
+          <div
+            key={c.label}
+            className="bg-terminal-surface border border-terminal-border rounded p-3"
+          >
+            <Tooltip text={TOOLTIPS[c.label]}>
+              <div className="text-xs text-terminal-muted mb-1">{c.label}</div>
+            </Tooltip>
+            <div className="text-lg font-bold">{c.value}</div>
+          </div>
+        ))}
+      </div>
+      {summary.date_range_start && summary.date_range_end && (
+        <div className="text-xs text-terminal-muted">
+          Date range: {summary.date_range_start} — {summary.date_range_end}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -1,0 +1,83 @@
+import { useState, useEffect, useCallback } from 'react'
+import { fetchReportSummary, fetchReportTrades } from '../api/client'
+import ActiveTradesTable from '../components/ActiveTradesTable'
+import MethodologyPanel from '../components/MethodologyPanel'
+import ResolvedTradesTable from '../components/ResolvedTradesTable'
+import StatusFilter from '../components/StatusFilter'
+import SummaryCards from '../components/SummaryCards'
+import type { SummaryResponse, ReportTradeItem } from '../types'
+
+export default function ReportPage() {
+  const [summary, setSummary] = useState<SummaryResponse | null>(null)
+  const [trades, setTrades] = useState<ReportTradeItem[]>([])
+  const [status, setStatus] = useState('all')
+  const [loading, setLoading] = useState(true)
+
+  const loadTrades = useCallback(async (s: string) => {
+    const t = await fetchReportTrades(s)
+    setTrades(t.trades)
+  }, [])
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      const [s] = await Promise.all([
+        fetchReportSummary(),
+        loadTrades(status),
+      ])
+      setSummary(s)
+      setLoading(false)
+    }
+    load()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleStatusChange = async (newStatus: string) => {
+    setStatus(newStatus)
+    await loadTrades(newStatus)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-terminal-muted text-sm py-16">
+        Loading report data...
+      </div>
+    )
+  }
+
+  if (summary && summary.total_tracked === 0) {
+    return (
+      <div className="flex-1 px-4 py-4">
+        <h1 className="text-lg font-bold mb-4">Backtesting Report</h1>
+        <div className="text-terminal-muted text-sm py-8 text-center">
+          No trades tracked yet. Run the daily cron to start tracking trades.
+        </div>
+      </div>
+    )
+  }
+
+  const activeTrades = trades.filter((t) => t.outcome === null)
+  const resolvedTrades = trades.filter((t) => t.outcome !== null)
+
+  return (
+    <div className="flex-1 px-4 py-4">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-bold">Backtesting Report</h1>
+        <StatusFilter value={status} onChange={handleStatusChange} />
+      </div>
+
+      {summary && <SummaryCards summary={summary} />}
+
+      <section className="mt-6">
+        <h2 className="text-sm font-bold text-terminal-muted mb-2">Active Trades</h2>
+        <ActiveTradesTable trades={activeTrades} onRefresh={() => loadTrades(status)} />
+      </section>
+
+      <section className="mt-6">
+        <h2 className="text-sm font-bold text-terminal-muted mb-2">Resolved Trades</h2>
+        <ResolvedTradesTable trades={resolvedTrades} />
+      </section>
+
+      <MethodologyPanel />
+    </div>
+  )
+}

--- a/frontend/src/pages/ScreenerPage.tsx
+++ b/frontend/src/pages/ScreenerPage.tsx
@@ -1,0 +1,91 @@
+import { useState, useEffect } from 'react'
+import CapitalSettings from '../components/CapitalSettings'
+import ControlBar from '../components/ControlBar'
+import FilterPanel, { DEFAULT_FILTERS, type Filters } from '../components/FilterPanel'
+import Legend from '../components/Legend'
+import RiskDashboard from '../components/RiskDashboard'
+import TradeTable from '../components/TradeTable'
+import { useTrades, useMarketStatus } from '../hooks/useTrades'
+
+export default function ScreenerPage() {
+  const [capital, setCapital] = useState(() => {
+    const saved = localStorage.getItem('capital')
+    return saved ? Number(saved) : 50000
+  })
+  const [margin, setMargin] = useState(() => {
+    const saved = localStorage.getItem('margin')
+    return saved ? Number(saved) : 0.3
+  })
+  const [filterOpen, setFilterOpen] = useState(false)
+  const [riskOpen, setRiskOpen] = useState(false)
+  const [legendOpen, setLegendOpen] = useState(false)
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS)
+
+  const { scanResult, loading, error, runScan } = useTrades()
+  const { status: marketStatus, loading: marketLoading, refresh: refreshMarket } = useMarketStatus()
+
+  useEffect(() => {
+    localStorage.setItem('capital', String(capital))
+  }, [capital])
+
+  useEffect(() => {
+    localStorage.setItem('margin', String(margin))
+  }, [margin])
+
+  return (
+    <>
+      <CapitalSettings
+        capital={capital}
+        margin={margin}
+        onCapitalChange={setCapital}
+        onMarginChange={setMargin}
+      />
+      <ControlBar
+        onScan={() => runScan()}
+        onToggleFilter={() => setFilterOpen(!filterOpen)}
+        onToggleRisk={() => setRiskOpen(!riskOpen)}
+        onToggleLegend={() => setLegendOpen(!legendOpen)}
+        loading={loading}
+        filterOpen={filterOpen}
+        legendOpen={legendOpen}
+      />
+
+      {riskOpen && (
+        <RiskDashboard
+          status={marketStatus}
+          loading={marketLoading}
+          onRefresh={refreshMarket}
+          onClose={() => setRiskOpen(false)}
+        />
+      )}
+
+      {legendOpen && (
+        <Legend onClose={() => setLegendOpen(false)} />
+      )}
+
+      {filterOpen && (
+        <FilterPanel filters={filters} onChange={setFilters} />
+      )}
+
+      {error && (
+        <div className="px-4 py-2 bg-terminal-red/10 border-b border-terminal-red/30 text-terminal-red text-sm">
+          {error}
+        </div>
+      )}
+
+      {scanResult && (
+        <div className="px-4 py-2 border-b border-terminal-border text-xs text-terminal-muted flex gap-4">
+          <span>Universe: {scanResult.universe_size}</span>
+          <span>Qualified: {scanResult.qualified_stocks}</span>
+          <span>Trades: {scanResult.trades_screened}</span>
+          <span>Scanned: {scanResult.scan_timestamp}</span>
+        </div>
+      )}
+
+      <TradeTable
+        trades={scanResult?.trades ?? []}
+        filters={filters}
+      />
+    </>
+  )
+}

--- a/frontend/src/test/ReportPage.test.tsx
+++ b/frontend/src/test/ReportPage.test.tsx
@@ -71,7 +71,7 @@ describe('SummaryCards', () => {
       total_tracked: 42,
       total_resolved: 30,
       total_active: 12,
-      hit_rate: 0.733,
+      hit_rate: 73.3,
       avg_return_pct: 2.15,
       avg_win_pct: 3.5,
       avg_loss_pct: -1.8,

--- a/frontend/src/test/ReportPage.test.tsx
+++ b/frontend/src/test/ReportPage.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import App from '../App'
+
+vi.mock('../hooks/useTrades', () => ({
+  useTrades: () => ({ scanResult: null, loading: false, error: null, runScan: vi.fn() }),
+  useMarketStatus: () => ({ status: null, loading: false, refresh: vi.fn() }),
+}))
+
+vi.mock('../api/client', () => ({
+  fetchReportSummary: vi.fn().mockResolvedValue({
+    total_tracked: 0, total_resolved: 0, total_active: 0,
+    hit_rate: null, avg_return_pct: null, avg_win_pct: null,
+    avg_loss_pct: null, win_loss_ratio: null,
+    date_range_start: null, date_range_end: null,
+  }),
+  fetchReportTrades: vi.fn().mockResolvedValue({ trades: [] }),
+}))
+
+function renderApp(route = '/') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <App />
+    </MemoryRouter>,
+  )
+}
+
+describe('Routing', () => {
+  it('renders the screener at /', () => {
+    renderApp('/')
+    expect(screen.getByText('OptionTerminal')).toBeInTheDocument()
+  })
+
+  it('renders the report page at /report', async () => {
+    renderApp('/report')
+    expect(await screen.findByText('Backtesting Report')).toBeInTheDocument()
+  })
+})
+
+describe('NavBar', () => {
+  it('shows nav links on the screener page', () => {
+    renderApp('/')
+    expect(screen.getByRole('link', { name: /screener/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /report/i })).toBeInTheDocument()
+  })
+
+  it('shows nav links on the report page', () => {
+    renderApp('/report')
+    expect(screen.getByRole('link', { name: /screener/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /report/i })).toBeInTheDocument()
+  })
+
+  it('navigates from screener to report', async () => {
+    renderApp('/')
+    await userEvent.click(screen.getByRole('link', { name: /report/i }))
+    expect(await screen.findByText('Backtesting Report')).toBeInTheDocument()
+  })
+
+  it('navigates from report to screener', async () => {
+    renderApp('/report')
+    await userEvent.click(screen.getByRole('link', { name: /screener/i }))
+    expect(screen.getByText('Run Scanner')).toBeInTheDocument()
+  })
+})
+
+describe('SummaryCards', () => {
+  it('displays all summary metrics from API', async () => {
+    const { fetchReportSummary } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValueOnce({
+      total_tracked: 42,
+      total_resolved: 30,
+      total_active: 12,
+      hit_rate: 0.733,
+      avg_return_pct: 2.15,
+      avg_win_pct: 3.5,
+      avg_loss_pct: -1.8,
+      win_loss_ratio: 1.94,
+      date_range_start: '2026-01-15',
+      date_range_end: '2026-04-01',
+    })
+
+    renderApp('/report')
+
+    expect(await screen.findByText('42')).toBeInTheDocument()
+    expect(screen.getByText('30')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('73.3%')).toBeInTheDocument()
+    expect(screen.getByText('2.15%')).toBeInTheDocument()
+    expect(screen.getByText('3.50%')).toBeInTheDocument()
+    expect(screen.getByText('-1.80%')).toBeInTheDocument()
+    expect(screen.getByText('1.94')).toBeInTheDocument()
+    expect(screen.getByText(/2026-01-15/)).toBeInTheDocument()
+    expect(screen.getByText(/2026-04-01/)).toBeInTheDocument()
+  })
+
+  it('shows empty state when total_tracked is zero', async () => {
+    const { fetchReportSummary } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValueOnce({
+      total_tracked: 0, total_resolved: 0, total_active: 0,
+      hit_rate: null, avg_return_pct: null, avg_win_pct: null,
+      avg_loss_pct: null, win_loss_ratio: null,
+      date_range_start: null, date_range_end: null,
+    })
+
+    renderApp('/report')
+    expect(await screen.findByText(/no trades tracked yet/i)).toBeInTheDocument()
+  })
+})
+
+const MOCK_SUMMARY_WITH_DATA = {
+  total_tracked: 5, total_resolved: 3, total_active: 2,
+  hit_rate: 0.6, avg_return_pct: 1.5, avg_win_pct: 3.0,
+  avg_loss_pct: -2.0, win_loss_ratio: 1.5,
+  date_range_start: '2026-01-01', date_range_end: '2026-04-01',
+}
+
+const MOCK_ACTIVE_TRADE = {
+  id: 1, snapshot_id: 1, snapshot_date: '2026-03-01', rank: 1,
+  symbol: 'AAPL', expiry: '2026-04-18', strike: 170, premium: 2.5,
+  pop: 0.72, delta: -0.28, theta: 0.05, implied_volatility: 0.32,
+  expected_value: 1.8, days_to_expiry: 48, support_level: 168,
+  current_price: 178.5, premium_yield: 1.47, open_interest: 1200,
+  safety_score: 82, adjusted_score: 78, next_earnings: '2026-05-01',
+  outcome: null, settlement_price: null, pnl_pct: null, days_remaining: 13,
+}
+
+describe('ActiveTradesTable', () => {
+  it('renders active trades with DTE, price, and strike', async () => {
+    const { fetchReportSummary, fetchReportTrades } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValueOnce(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades.mockResolvedValueOnce({ trades: [MOCK_ACTIVE_TRADE] })
+
+    renderApp('/report')
+
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+    expect(screen.getByText('170')).toBeInTheDocument()
+    expect(screen.getByText('178.5')).toBeInTheDocument()
+    expect(screen.getByText('13d')).toBeInTheDocument()
+  })
+})
+
+const MOCK_RESOLVED_TRADE = {
+  id: 2, snapshot_id: 1, snapshot_date: '2026-02-01', rank: 3,
+  symbol: 'MSFT', expiry: '2026-03-21', strike: 400, premium: 5.0,
+  pop: 0.68, delta: -0.32, theta: 0.04, implied_volatility: 0.28,
+  expected_value: 3.4, days_to_expiry: 48, support_level: 395,
+  current_price: 410, premium_yield: 1.25, open_interest: 800,
+  safety_score: 75, adjusted_score: 71, next_earnings: null,
+  outcome: 'OTM', settlement_price: 405.0, pnl_pct: 1.25, days_remaining: null,
+}
+
+describe('ResolvedTradesTable', () => {
+  it('renders resolved trades with outcome, settlement price, P&L, and scores', async () => {
+    const { fetchReportSummary, fetchReportTrades } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValueOnce(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades.mockResolvedValueOnce({ trades: [MOCK_RESOLVED_TRADE] })
+
+    renderApp('/report')
+
+    expect(await screen.findByText('MSFT')).toBeInTheDocument()
+    expect(screen.getByText('OTM')).toBeInTheDocument()
+    expect(screen.getByText('405')).toBeInTheDocument()
+    expect(screen.getByText('+1.25%')).toBeInTheDocument()
+    expect(screen.getByText('75')).toBeInTheDocument()
+  })
+})
+
+describe('StatusFilter', () => {
+  it('re-fetches trades when filter changes', async () => {
+    const { fetchReportSummary, fetchReportTrades } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValue(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades
+      .mockResolvedValueOnce({ trades: [MOCK_ACTIVE_TRADE, MOCK_RESOLVED_TRADE] })
+      .mockResolvedValueOnce({ trades: [MOCK_ACTIVE_TRADE] })
+
+    renderApp('/report')
+
+    // Wait for initial load
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+    expect(screen.getByText('MSFT')).toBeInTheDocument()
+
+    // Click "Active" filter
+    await userEvent.click(screen.getByRole('button', { name: /^active$/i }))
+
+    // Should have re-fetched with status=active
+    expect(fetchReportTrades).toHaveBeenLastCalledWith('active')
+  })
+})
+
+describe('RefreshPrices', () => {
+  it('calls fetchReportTrades when refresh prices button is clicked', async () => {
+    const { fetchReportSummary, fetchReportTrades } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValue(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades
+      .mockResolvedValueOnce({ trades: [MOCK_ACTIVE_TRADE] })
+      .mockResolvedValueOnce({ trades: [{ ...MOCK_ACTIVE_TRADE, current_price: 180.0 }] })
+
+    renderApp('/report')
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+
+    const callCountBefore = fetchReportTrades.mock.calls.length
+    await userEvent.click(screen.getByRole('button', { name: /refresh prices/i }))
+    expect(fetchReportTrades.mock.calls.length).toBeGreaterThan(callCountBefore)
+  })
+})
+
+describe('MethodologyPanel', () => {
+  it('is collapsed by default and expands on click', async () => {
+    const { fetchReportSummary, fetchReportTrades } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValue(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades.mockResolvedValue({ trades: [MOCK_ACTIVE_TRADE] })
+
+    renderApp('/report')
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+
+    // Panel content should not be visible initially
+    expect(screen.queryByText(/OTM \(Out of the Money\)/i)).not.toBeInTheDocument()
+
+    // Click to expand
+    await userEvent.click(screen.getByRole('button', { name: /methodology/i }))
+    expect(screen.getByText(/OTM \(Out of the Money\)/i)).toBeInTheDocument()
+
+    // Click to collapse
+    await userEvent.click(screen.getByRole('button', { name: /methodology/i }))
+    expect(screen.queryByText(/OTM \(Out of the Money\)/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('Tooltips', () => {
+  it('summary card labels have tooltip text', async () => {
+    const { fetchReportSummary, fetchReportTrades } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValue(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades.mockResolvedValue({ trades: [MOCK_ACTIVE_TRADE] })
+
+    renderApp('/report')
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+
+    // Hover over "Hit Rate" label to reveal tooltip
+    const hitRateLabel = screen.getByText('Hit Rate')
+    await userEvent.hover(hitRateLabel)
+    expect(await screen.findByText(/percentage of resolved trades that expired OTM/i)).toBeInTheDocument()
+  })
+})
+
+describe('EmptyTables', () => {
+  it('shows empty state messages when no trades exist', async () => {
+    const { fetchReportSummary, fetchReportTrades } = await import('../api/client') as any
+    fetchReportSummary.mockResolvedValueOnce({
+      ...MOCK_SUMMARY_WITH_DATA,
+      total_tracked: 1,
+    })
+    fetchReportTrades.mockResolvedValueOnce({ trades: [] })
+
+    renderApp('/report')
+
+    expect(await screen.findByText(/no active trades/i)).toBeInTheDocument()
+    expect(screen.getByText(/no resolved trades/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom/vitest'
+
+// jsdom localStorage stub
+const store: Record<string, string> = {}
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, val: string) => { store[key] = val },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { for (const k in store) delete store[k] },
+  },
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -27,6 +27,51 @@ export interface ScanResult {
   scan_timestamp: string
 }
 
+export interface SummaryResponse {
+  total_tracked: number
+  total_resolved: number
+  total_active: number
+  hit_rate: number | null
+  avg_return_pct: number | null
+  avg_win_pct: number | null
+  avg_loss_pct: number | null
+  win_loss_ratio: number | null
+  date_range_start: string | null
+  date_range_end: string | null
+}
+
+export interface ReportTradeItem {
+  id: number
+  snapshot_id: number
+  snapshot_date: string
+  rank: number
+  symbol: string
+  expiry: string
+  strike: number
+  premium: number
+  pop: number
+  delta: number
+  theta: number | null
+  implied_volatility: number
+  expected_value: number
+  days_to_expiry: number
+  support_level: number
+  current_price: number
+  premium_yield: number
+  open_interest: number
+  safety_score: number | null
+  adjusted_score: number | null
+  next_earnings: string | null
+  outcome: string | null
+  settlement_price: number | null
+  pnl_pct: number | null
+  days_remaining: number | null
+}
+
+export interface TradesResponse {
+  trades: ReportTradeItem[]
+}
+
 export interface MarketRiskStatus {
   vix_level: number
   vix_threshold: number

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -12,5 +13,10 @@ export default defineConfig({
   build: {
     outDir: '../public',
     emptyOutDir: true,
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts',
   },
 })


### PR DESCRIPTION
## Summary
- Adds `/report` route with `react-router-dom`, nav bar on both pages
- Report page: summary cards (with tooltips), active trades table (DTE + refresh prices), resolved trades table (outcome/P&L coloring), status filter, collapsible methodology panel
- Graceful empty states when no data exists
- Extracted `ScreenerPage` and `CapitalSettings` from `App` to support routing
- Set up vitest + @testing-library/react with 15 behavior tests

## Test plan
- [ ] `npm test` passes all 15 tests
- [ ] `npm run build` compiles cleanly
- [ ] Navigate between `/` and `/report` ��� both render correctly
- [ ] Summary cards display correct metrics with tooltips on hover
- [ ] Active trades show DTE countdown, "Refresh Prices" re-fetches
- [ ] Resolved trades show OTM/ITM coloring, P&L, settlement price
- [ ] Status filter switches between all/active/resolved
- [ ] Methodology panel expands/collapses
- [ ] Empty state shown when no trades tracked

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)