### PR TITLE
[#17] AV stack live end-to-end (AVClient + cache + adapters + as_of)

### DIFF
--- a/app/backup.py
+++ b/app/backup.py
@@ -31,6 +31,10 @@ def backup_db_to_s3(
     client.upload_file(db_path, bucket, key)
     logger.info("Uploaded %s to s3://%s/%s", db_path, bucket, key)
 
+    latest_key = "backups/screener-latest.db"
+    client.upload_file(db_path, bucket, latest_key)
+    logger.info("Uploaded immortal copy to s3://%s/%s", bucket, latest_key)
+
     _prune_old_backups(client, bucket, retention_days)
 
     return key
@@ -47,7 +51,9 @@ def _prune_old_backups(
     to_delete = [
         obj["Key"]
         for obj in contents
-        if (d := _parse_backup_date(obj["Key"])) is not None and d < cutoff
+        if obj["Key"] != "backups/screener-latest.db"
+        and (d := _parse_backup_date(obj["Key"])) is not None
+        and d < cutoff
     ]
 
     if to_delete:
@@ -56,6 +62,24 @@ def _prune_old_backups(
             Delete={"Objects": [{"Key": k} for k in to_delete]},
         )
         logger.info("Pruned %d old backup(s)", len(to_delete))
+
+
+def restore_db_from_s3(
+    db_path: str,
+    bucket: str,
+    region: str,
+    aws_access_key_id: str = "",
+    aws_secret_access_key: str = "",
+) -> None:
+    """Download the latest DB from S3 for cache hydration."""
+    client_kwargs = {"region_name": region}
+    if aws_access_key_id and aws_secret_access_key:
+        client_kwargs["aws_access_key_id"] = aws_access_key_id
+        client_kwargs["aws_secret_access_key"] = aws_secret_access_key
+    client = boto3.client("s3", **client_kwargs)
+    key = "backups/screener-latest.db"
+    client.download_file(bucket, key, db_path)
+    logger.info("Restored %s from s3://%s/%s", db_path, bucket, key)
 
 
 def run_backup(settings) -> None:

--- a/app/db.py
+++ b/app/db.py
@@ -181,6 +181,17 @@ def get_trades_by_status(conn: sqlite3.Connection, status: str) -> list[dict]:
 
 def _create_schema(conn: sqlite3.Connection) -> None:
     conn.executescript("""
+        CREATE TABLE IF NOT EXISTS backtest_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            completed_at TEXT,
+            date_range_start TEXT NOT NULL,
+            date_range_end TEXT NOT NULL,
+            scan_frequency TEXT NOT NULL,
+            strategy_params TEXT NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS snapshots (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             snapshot_date TEXT NOT NULL,
@@ -189,7 +200,8 @@ def _create_schema(conn: sqlite3.Connection) -> None:
             trades_screened INTEGER NOT NULL,
             market_risk_elevated INTEGER NOT NULL,
             vix_level REAL NOT NULL,
-            spy_price REAL NOT NULL
+            spy_price REAL NOT NULL,
+            backtest_run_id INTEGER REFERENCES backtest_runs(id)
         );
 
         CREATE TABLE IF NOT EXISTS snapshot_trades (

--- a/app/engine/market_risk.py
+++ b/app/engine/market_risk.py
@@ -11,6 +11,7 @@ during market stress.
 """
 
 import logging
+from datetime import date
 
 from app.models.market import MarketRiskStatus
 from app.providers.base import MarketDataProvider
@@ -23,14 +24,16 @@ VIX_THRESHOLD = 25.0
 SMA_PERIOD = 20
 
 
-def assess_market_risk(provider: MarketDataProvider) -> MarketRiskStatus:
+def assess_market_risk(
+    provider: MarketDataProvider, *, as_of: date | None = None
+) -> MarketRiskStatus:
     """Evaluate current market risk from VIX and SPY.
 
     Returns a MarketRiskStatus indicating whether risk is elevated
     and why. Used by the pipeline to decide how many trades to output.
     """
-    vix_level = _get_vix(provider)
-    spy_price, spy_sma = _get_spy_trend(provider)
+    vix_level = _get_vix(provider, as_of=as_of)
+    spy_price, spy_sma = _get_spy_trend(provider, as_of=as_of)
     spy_above_sma = spy_price >= spy_sma
 
     reasons: list[str] = []
@@ -55,10 +58,11 @@ def assess_market_risk(provider: MarketDataProvider) -> MarketRiskStatus:
     )
 
 
-def _get_vix(provider: MarketDataProvider) -> float:
-    """Fetch the current VIX level."""
+def _get_vix(
+    provider: MarketDataProvider, *, as_of: date | None = None
+) -> float:
     try:
-        hist = provider.get_price_history(VIX_SYMBOL, period="5d", interval="1d")
+        hist = provider.get_price_history(VIX_SYMBOL, period="5d", interval="1d", as_of=as_of)
         if hist.empty:
             return 0.0
         return float(hist["Close"].iloc[-1])
@@ -67,13 +71,11 @@ def _get_vix(provider: MarketDataProvider) -> float:
         return 0.0
 
 
-def _get_spy_trend(provider: MarketDataProvider) -> tuple[float, float]:
-    """Fetch SPY current price and 20-day SMA.
-
-    Returns (current_price, sma_20).
-    """
+def _get_spy_trend(
+    provider: MarketDataProvider, *, as_of: date | None = None
+) -> tuple[float, float]:
     try:
-        hist = provider.get_price_history(SPY_SYMBOL, period="2mo", interval="1d")
+        hist = provider.get_price_history(SPY_SYMBOL, period="2mo", interval="1d", as_of=as_of)
         if hist.empty or len(hist) < SMA_PERIOD:
             return 0.0, 0.0
         current = float(hist["Close"].iloc[-1])

--- a/app/engine/options_screener.py
+++ b/app/engine/options_screener.py
@@ -49,19 +49,21 @@ def screen_options_for_stock(
     stock: StockProfile,
     market_provider: MarketDataProvider,
     options_provider: OptionsDataProvider,
+    *,
+    as_of: date | None = None,
 ) -> list[ScreenedTrade]:
     """Screen all qualifying put options for a single stock.
 
     Returns a list of ScreenedTrade objects for contracts that pass
     all filters. May return an empty list if no contracts qualify.
     """
-    today = date.today()
+    today = as_of or date.today()
     target_min = today + timedelta(days=MIN_DTE)
     target_max = today + timedelta(days=MAX_DTE)
 
     # Get available expiry dates
     try:
-        expiry_dates = options_provider.get_expiry_dates(stock.symbol)
+        expiry_dates = options_provider.get_expiry_dates(stock.symbol, as_of=as_of)
     except Exception:
         logger.warning("Failed to get expiry dates for %s", stock.symbol, exc_info=True)
         return []
@@ -73,7 +75,7 @@ def screen_options_for_stock(
 
     # Find support level for strike validation
     support = find_support_level(
-        market_provider, stock.symbol, stock.current_price
+        market_provider, stock.symbol, stock.current_price, as_of=as_of
     )
     if support is None:
         support = stock.current_price * FALLBACK_SUPPORT_DISCOUNT
@@ -82,7 +84,7 @@ def screen_options_for_stock(
     trades: list[ScreenedTrade] = []
     for expiry_str in qualifying_expiries:
         try:
-            chain = options_provider.get_options_chain(stock.symbol, expiry_str)
+            chain = options_provider.get_options_chain(stock.symbol, expiry_str, as_of=as_of)
         except Exception:
             logger.warning(
                 "Failed to get options chain for %s exp %s",

--- a/app/engine/pipeline.py
+++ b/app/engine/pipeline.py
@@ -14,7 +14,7 @@ a single scan operation.
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from app.config import settings
 from app.engine.market_risk import assess_market_risk
@@ -34,6 +34,7 @@ def run_scan(
     news_provider: NewsProvider | None = None,
     symbols: list[str] | None = None,
     max_trades: int | None = None,
+    as_of: date | None = None,
 ) -> ScanResult:
     """Execute the full screening pipeline.
 
@@ -52,7 +53,7 @@ def run_scan(
 
     # Step 1: Universe filter
     logger.info("Starting pipeline scan")
-    universe_result = filter_universe(market_provider, symbols=symbols)
+    universe_result = filter_universe(market_provider, symbols=symbols, as_of=as_of)
     qualified_symbols = universe_result.qualified
 
     logger.info(
@@ -67,7 +68,7 @@ def run_scan(
     # Step 2: Fetch profiles and apply risk filters
     profiles = {}
     for symbol in qualified_symbols:
-        profile = market_provider.get_stock_info(symbol)
+        profile = market_provider.get_stock_info(symbol, as_of=as_of)
         if profile is not None:
             profiles[symbol] = profile
 
@@ -76,6 +77,7 @@ def run_scan(
         profiles=profiles,
         market_provider=market_provider,
         news_provider=news_provider,
+        as_of=as_of,
     )
     filtered_symbols = risk_result.passed
 
@@ -92,7 +94,7 @@ def run_scan(
         )
 
     # Step 3: Assess market risk (VIX + SPY)
-    market_risk = assess_market_risk(market_provider)
+    market_risk = assess_market_risk(market_provider, as_of=as_of)
 
     if market_risk.risk_elevated:
         max_trades = max(1, max_trades // 2)
@@ -108,7 +110,9 @@ def run_scan(
         if stock is None:
             continue
 
-        trades = screen_options_for_stock(stock, market_provider, options_provider)
+        trades = screen_options_for_stock(
+            stock, market_provider, options_provider, as_of=as_of
+        )
         all_trades.extend(trades)
 
         logger.debug(
@@ -132,7 +136,8 @@ def run_scan(
             continue
 
         safety = calculate_safety_score(
-            trade, profile, market_risk, market_provider, options_provider
+            trade, profile, market_risk, market_provider, options_provider,
+            as_of=as_of,
         )
         adjusted = calculate_adjusted_score(trade.expected_value, safety.score)
         scored_trades.append((trade, safety.score, adjusted))

--- a/app/engine/risk_filter.py
+++ b/app/engine/risk_filter.py
@@ -69,6 +69,7 @@ def apply_risk_filters(
     profiles: dict[str, StockProfile],
     market_provider: MarketDataProvider,
     news_provider: NewsProvider | None = None,
+    as_of: date | None = None,
 ) -> RiskFilterResult:
     """Apply all risk filters to a list of symbols.
 
@@ -97,8 +98,8 @@ def apply_risk_filters(
             result.excluded_premarket.append(symbol)
             continue
 
-        # Filter 2: Earnings within 21 days (free — uses yfinance calendar)
-        if _has_upcoming_earnings(symbol, market_provider):
+        # Filter 2: Earnings within 21 days
+        if _has_upcoming_earnings(symbol, market_provider, as_of=as_of):
             result.excluded_earnings.append(symbol)
             continue
 
@@ -108,7 +109,7 @@ def apply_risk_filters(
     # Run last, with rate limiting, on the reduced pool
     for symbol in after_cheap_filters:
         if news_provider is not None:
-            if _has_negative_news(symbol, news_provider):
+            if _has_negative_news(symbol, news_provider, as_of=as_of):
                 result.excluded_news.append(symbol)
                 continue
 
@@ -126,10 +127,12 @@ def apply_risk_filters(
     return result
 
 
-def _has_negative_news(symbol: str, news_provider: NewsProvider) -> bool:
+def _has_negative_news(
+    symbol: str, news_provider: NewsProvider, *, as_of: date | None = None
+) -> bool:
     """Check if any recent headlines contain negative keywords."""
     try:
-        headlines = news_provider.get_recent_headlines(symbol, hours=24)
+        headlines = news_provider.get_recent_headlines(symbol, hours=24, as_of=as_of)
         for headline in headlines:
             title_lower = headline.title.lower()
             if any(kw in title_lower for kw in NEGATIVE_KEYWORDS):
@@ -160,7 +163,9 @@ def _has_excessive_premarket_move(profile: StockProfile) -> bool:
     return False
 
 
-def _has_upcoming_earnings(symbol: str, provider: MarketDataProvider) -> bool:
+def _has_upcoming_earnings(
+    symbol: str, provider: MarketDataProvider, *, as_of: date | None = None
+) -> bool:
     """Check if earnings are within 21 days.
 
     yfinance's ticker.calendar returns a dict with:
@@ -186,7 +191,7 @@ def _has_upcoming_earnings(symbol: str, provider: MarketDataProvider) -> bool:
         if not isinstance(earnings_dates, list):
             earnings_dates = [earnings_dates]
 
-        today = date.today()
+        today = as_of or date.today()
         for ed in earnings_dates:
             # Convert to date if it's a datetime
             if hasattr(ed, "date"):

--- a/app/engine/safety_score.py
+++ b/app/engine/safety_score.py
@@ -16,9 +16,9 @@ Final formula:
 """
 
 import logging
+from datetime import date
 
 import numpy as np
-import pandas as pd
 
 from app.models.market import MarketRiskStatus
 from app.models.option import ScreenedTrade
@@ -43,6 +43,8 @@ def calculate_safety_score(
     market_risk: MarketRiskStatus,
     market_provider: MarketDataProvider,
     options_provider: OptionsDataProvider,
+    *,
+    as_of: date | None = None,
 ) -> SafetyResult:
     """Compute the composite safety score for a screened trade.
 
@@ -51,9 +53,9 @@ def calculate_safety_score(
     """
     dist = _distance_from_support(trade)
     premarket = _premarket_stability(profile)
-    corr = _sector_correlation(profile.symbol, market_provider)
+    corr = _sector_correlation(profile.symbol, market_provider, as_of=as_of)
     iv_rank = _iv_rank_stability(trade)
-    flow = _institutional_flow(trade, options_provider)
+    flow = _institutional_flow(trade, options_provider, as_of=as_of)
     market = _market_risk_score(market_risk)
 
     components = SafetyComponents(
@@ -113,15 +115,17 @@ def _premarket_stability(profile: StockProfile) -> float:
     return min(max(score, 0.0), 1.0)
 
 
-def _sector_correlation(symbol: str, provider: MarketDataProvider) -> float:
+def _sector_correlation(
+    symbol: str, provider: MarketDataProvider, *, as_of: date | None = None
+) -> float:
     """Inverse correlation with SPY over 30 days.
 
     Lower correlation = more diversification benefit = higher score.
     Score = 1 - |correlation|, so uncorrelated stocks score highest.
     """
     try:
-        stock_hist = provider.get_price_history(symbol, period="2mo", interval="1d")
-        spy_hist = provider.get_price_history("SPY", period="2mo", interval="1d")
+        stock_hist = provider.get_price_history(symbol, period="2mo", interval="1d", as_of=as_of)
+        spy_hist = provider.get_price_history("SPY", period="2mo", interval="1d", as_of=as_of)
 
         if stock_hist.empty or spy_hist.empty or len(stock_hist) < 20:
             return 0.5  # Default if insufficient data
@@ -164,6 +168,8 @@ def _iv_rank_stability(trade: ScreenedTrade) -> float:
 def _institutional_flow(
     trade: ScreenedTrade,
     options_provider: OptionsDataProvider,
+    *,
+    as_of: date | None = None,
 ) -> float:
     """Put/call open interest ratio as a proxy for institutional flow.
 
@@ -174,7 +180,7 @@ def _institutional_flow(
     """
     try:
         chain = options_provider.get_options_chain(
-            trade.symbol, trade.expiry.isoformat()
+            trade.symbol, trade.expiry.isoformat(), as_of=as_of
         )
         total_put_oi = sum(p.open_interest for p in chain.puts)
         total_call_oi = sum(c.open_interest for c in chain.calls)

--- a/app/engine/technicals.py
+++ b/app/engine/technicals.py
@@ -13,6 +13,7 @@ This is a pragmatic heuristic for a POC. More sophisticated methods
 """
 
 import logging
+from datetime import date
 
 import numpy as np
 import pandas as pd
@@ -30,6 +31,8 @@ def find_support_level(
     provider: MarketDataProvider,
     symbol: str,
     current_price: float,
+    *,
+    as_of: date | None = None,
 ) -> float | None:
     """Find the nearest support level below the current price.
 
@@ -42,7 +45,7 @@ def find_support_level(
         The nearest support level below current_price, or None if
         no support level is found (falls back to caller's default).
     """
-    hist = provider.get_price_history(symbol, period=LOOKBACK_PERIOD)
+    hist = provider.get_price_history(symbol, period=LOOKBACK_PERIOD, as_of=as_of)
 
     if hist.empty or len(hist) < WINDOW_SIZE * 2 + 1:
         logger.warning("Insufficient price history for %s", symbol)

--- a/app/engine/universe.py
+++ b/app/engine/universe.py
@@ -18,6 +18,7 @@ applies per-contract, not per-stock.
 
 import logging
 from dataclasses import dataclass, field
+from datetime import date
 
 from app.models.stock import StockProfile, UniverseFilterResult
 from app.providers.base import MarketDataProvider
@@ -43,6 +44,7 @@ class _FilterTracker:
 def filter_universe(
     provider: MarketDataProvider,
     symbols: list[str] | None = None,
+    as_of: date | None = None,
 ) -> UniverseFilterResult:
     """Run fundamental filters on S&P 500 stocks.
 
@@ -60,7 +62,7 @@ def filter_universe(
     qualified: list[str] = []
 
     for symbol in symbols:
-        profile = provider.get_stock_info(symbol)
+        profile = provider.get_stock_info(symbol, as_of=as_of)
 
         if profile is None:
             tracker.exclude(symbol, "data_unavailable")

--- a/app/models/stock.py
+++ b/app/models/stock.py
@@ -14,7 +14,8 @@ class StockProfile(BaseModel):
     avg_volume: float  # Average daily volume in shares
     current_price: float
     previous_close: float
-    pre_market_price: float | None = None  # None if not available
+    pre_market_price: float | None = None
+    beta: float | None = None
 
 
 class UniverseFilterResult(BaseModel):

--- a/app/providers/av_adapters.py
+++ b/app/providers/av_adapters.py
@@ -1,0 +1,209 @@
+"""Thin adapters translating provider ABCs to AVClient calls."""
+
+import json
+import logging
+from datetime import date, datetime, timedelta, timezone
+
+import pandas as pd
+
+from app.models.option import Headline, OptionContract, OptionsChain
+from app.models.stock import StockProfile
+from app.providers.av_client import AVClient
+from app.providers.base import MarketDataProvider, NewsProvider, OptionsDataProvider
+
+logger = logging.getLogger(__name__)
+
+_SP500_FILE = __import__("pathlib").Path(__file__).parent.parent / "data" / "sp500.json"
+
+
+def _safe_float(value: str | None, default: float = 0.0) -> float:
+    if value is None or value == "None" or value == "-":
+        return default
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_int(value: str | None, default: int = 0) -> int:
+    if value is None or value == "None" or value == "-":
+        return default
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+class AVMarketDataAdapter(MarketDataProvider):
+    def __init__(self, client: AVClient) -> None:
+        self._client = client
+
+    def get_stock_info(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> StockProfile | None:
+        try:
+            overview = self._client.get_overview(symbol, as_of=as_of)
+            balance = self._client.get_balance_sheet(symbol, as_of=as_of)
+        except Exception:
+            logger.warning("Failed to fetch stock info for %s", symbol, exc_info=True)
+            return None
+
+        if not overview.get("Symbol"):
+            return None
+
+        ebitda = _safe_float(overview.get("EBITDA"))
+        quarterly = balance.get("quarterlyReports", [])
+        total_debt = 0.0
+        if quarterly:
+            total_debt = _safe_float(quarterly[0].get("shortLongTermDebtTotal"))
+
+        debt_to_ebitda = (total_debt / ebitda) if ebitda > 0 else float("inf")
+
+        current_price = _safe_float(
+            overview.get("50DayMovingAverage"),
+            _safe_float(overview.get("AnalystTargetPrice")),
+        )
+
+        return StockProfile(
+            symbol=overview["Symbol"],
+            name=overview.get("Name", symbol),
+            sector=overview.get("Sector", "Unknown"),
+            market_cap=_safe_float(overview.get("MarketCapitalization")),
+            net_income=0.0,
+            roe=_safe_float(overview.get("ReturnOnEquityTTM")),
+            debt_to_ebitda=debt_to_ebitda,
+            avg_volume=0.0,
+            current_price=current_price,
+            previous_close=current_price,
+            beta=_safe_float(overview.get("Beta")) or None,
+        )
+
+    def get_price_history(
+        self,
+        symbol: str,
+        period: str = "3mo",
+        interval: str = "1d",
+        *,
+        as_of: date | None = None,
+    ) -> pd.DataFrame:
+        try:
+            data = self._client.get_price_history(symbol, as_of=as_of)
+        except Exception:
+            logger.warning("Failed to fetch price history for %s", symbol, exc_info=True)
+            return pd.DataFrame()
+
+        ts_key = next(
+            (k for k in data if "Time Series" in k),
+            None,
+        )
+        if ts_key is None:
+            return pd.DataFrame()
+
+        series = data[ts_key]
+        rows = []
+        for date_str, values in series.items():
+            rows.append({
+                "Date": pd.Timestamp(date_str),
+                "Open": _safe_float(values.get("1. open")),
+                "High": _safe_float(values.get("2. high")),
+                "Low": _safe_float(values.get("3. low")),
+                "Close": _safe_float(values.get("4. close")),
+                "Volume": _safe_int(values.get("6. volume",
+                                               values.get("5. volume"))),
+            })
+
+        if not rows:
+            return pd.DataFrame()
+
+        df = pd.DataFrame(rows).set_index("Date").sort_index()
+
+        if as_of is not None:
+            df = df[df.index <= pd.Timestamp(as_of)]
+
+        return df
+
+    def get_sp500_symbols(self) -> list[str]:
+        try:
+            with open(_SP500_FILE) as f:
+                return json.load(f)
+        except Exception:
+            logger.warning("Failed to load S&P 500 list", exc_info=True)
+            return []
+
+
+class AVOptionsAdapter(OptionsDataProvider):
+    def __init__(self, client: AVClient) -> None:
+        self._client = client
+
+    def get_expiry_dates(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> list[str]:
+        data = self._client.get_options_chain(symbol, as_of=as_of)
+        expiries = sorted({c["expiration"] for c in data.get("data", [])})
+        return expiries
+
+    def get_options_chain(
+        self, symbol: str, expiry: str, *, as_of: date | None = None
+    ) -> OptionsChain:
+        data = self._client.get_options_chain(symbol, as_of=as_of)
+        expiry_date = date.fromisoformat(expiry)
+
+        puts = []
+        calls = []
+        for c in data.get("data", []):
+            if c["expiration"] != expiry:
+                continue
+            contract = OptionContract(
+                symbol=symbol,
+                expiry=expiry_date,
+                strike=_safe_float(c.get("strike")),
+                option_type=c.get("type", "put"),
+                bid=_safe_float(c.get("bid")),
+                ask=_safe_float(c.get("ask")),
+                last_price=_safe_float(c.get("last")),
+                delta=_safe_float(c.get("delta")) or None,
+                theta=_safe_float(c.get("theta")) or None,
+                gamma=_safe_float(c.get("gamma")) or None,
+                implied_volatility=_safe_float(c.get("implied_volatility")),
+                open_interest=_safe_int(c.get("open_interest")),
+                volume=_safe_int(c.get("volume")),
+            )
+            if c.get("type") == "put":
+                puts.append(contract)
+            else:
+                calls.append(contract)
+
+        return OptionsChain(symbol=symbol, expiry=expiry_date, puts=puts, calls=calls)
+
+
+class AVNewsAdapter(NewsProvider):
+    def __init__(self, client: AVClient) -> None:
+        self._client = client
+
+    def get_recent_headlines(
+        self, symbol: str, hours: int = 24, *, as_of: date | None = None
+    ) -> list[Headline]:
+        ref_time = datetime.now(timezone.utc)
+        if as_of is not None:
+            ref_time = datetime.combine(as_of, datetime.min.time(), tzinfo=timezone.utc)
+
+        time_from = (ref_time - timedelta(hours=hours)).strftime("%Y%m%dT%H%M")
+        time_to = ref_time.strftime("%Y%m%dT%H%M") if as_of is not None else None
+
+        try:
+            data = self._client.get_news_sentiment(
+                symbol, time_from=time_from, time_to=time_to
+            )
+        except Exception:
+            logger.warning("News fetch failed for %s", symbol, exc_info=True)
+            return []
+
+        headlines = []
+        for article in data.get("feed", []):
+            headlines.append(Headline(
+                title=article.get("title", ""),
+                source=article.get("source", ""),
+                published_at=article.get("time_published", ""),
+                url=article.get("url"),
+            ))
+        return headlines

--- a/app/providers/av_cache.py
+++ b/app/providers/av_cache.py
@@ -1,0 +1,126 @@
+"""SQLite-backed cache with TTL and stale-on-error semantics for AV data."""
+
+import json
+import logging
+import sqlite3
+import time
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class AVCache:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._create_tables()
+
+    def get_or_fetch(
+        self,
+        key: str,
+        ttl_seconds: int,
+        fetcher: Callable[[], Any],
+        *,
+        bypass_cache: bool = False,
+    ) -> Any:
+        stale_payload: str | None = None
+
+        if not bypass_cache:
+            row = self._conn.execute(
+                "SELECT payload, cached_at FROM av_cache WHERE cache_key = ?",
+                (key,),
+            ).fetchone()
+            if row is not None:
+                cached_at = row[1]
+                if time.time() - cached_at < ttl_seconds:
+                    return json.loads(row[0])
+                stale_payload = row[0]
+
+        try:
+            result = fetcher()
+        except Exception:
+            if stale_payload is not None:
+                logger.warning("Fetch failed for %s, serving stale cache entry", key)
+                return json.loads(stale_payload)
+            raise
+
+        self._conn.execute(
+            """INSERT OR REPLACE INTO av_cache (cache_key, payload, cached_at)
+               VALUES (?, ?, ?)""",
+            (key, json.dumps(result), time.time()),
+        )
+        self._conn.commit()
+        return result
+
+    def store_options_chain(
+        self, symbol: str, as_of_date: str, contracts: list[dict]
+    ) -> None:
+        now = time.time()
+        self._conn.executemany(
+            """INSERT OR REPLACE INTO av_options_chain_cache
+               (symbol, as_of_date, expiration, strike, option_type,
+                bid, ask, last_price, mark, volume, open_interest,
+                implied_volatility, delta, gamma, theta, vega, rho, cached_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    symbol, as_of_date, c["expiration"], c["strike"], c["option_type"],
+                    c.get("bid"), c.get("ask"), c.get("last_price"), c.get("mark"),
+                    c.get("volume"), c.get("open_interest"),
+                    c.get("implied_volatility"), c.get("delta"), c.get("gamma"),
+                    c.get("theta"), c.get("vega"), c.get("rho"), now,
+                )
+                for c in contracts
+            ],
+        )
+        self._conn.commit()
+
+    def get_options_chain(self, symbol: str, as_of_date: str) -> list[dict] | None:
+        rows = self._conn.execute(
+            """SELECT expiration, strike, option_type, bid, ask, last_price,
+                      mark, volume, open_interest, implied_volatility,
+                      delta, gamma, theta, vega, rho
+               FROM av_options_chain_cache
+               WHERE symbol = ? AND as_of_date = ?
+               ORDER BY expiration, strike""",
+            (symbol, as_of_date),
+        ).fetchall()
+        if not rows:
+            return None
+        columns = [
+            "expiration", "strike", "option_type", "bid", "ask", "last_price",
+            "mark", "volume", "open_interest", "implied_volatility",
+            "delta", "gamma", "theta", "vega", "rho",
+        ]
+        return [dict(zip(columns, row)) for row in rows]
+
+    def _create_tables(self) -> None:
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS av_cache (
+                cache_key TEXT PRIMARY KEY,
+                payload TEXT NOT NULL,
+                cached_at REAL NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS av_options_chain_cache (
+                symbol TEXT NOT NULL,
+                as_of_date TEXT NOT NULL,
+                expiration TEXT NOT NULL,
+                strike REAL NOT NULL,
+                option_type TEXT NOT NULL,
+                bid REAL,
+                ask REAL,
+                last_price REAL,
+                mark REAL,
+                volume INTEGER,
+                open_interest INTEGER,
+                implied_volatility REAL,
+                delta REAL,
+                gamma REAL,
+                theta REAL,
+                vega REAL,
+                rho REAL,
+                cached_at REAL NOT NULL,
+                PRIMARY KEY (symbol, as_of_date, expiration, strike, option_type)
+            );
+        """)

--- a/app/providers/av_client.py
+++ b/app/providers/av_client.py
@@ -1,0 +1,239 @@
+"""AlphaVantage HTTP client with rate limiting, retry, and cache integration."""
+
+import logging
+import sqlite3
+import time
+from collections import deque
+from datetime import date
+
+import httpx
+
+from app.providers.av_cache import AVCache
+
+logger = logging.getLogger(__name__)
+
+AV_BASE_URL = "https://www.alphavantage.co/query"
+RATE_LIMIT = 75
+RATE_WINDOW = 60  # seconds
+MAX_RETRIES = 3
+RETRY_BACKOFF = 1.0
+
+
+class AVClient:
+    def __init__(
+        self,
+        api_key: str,
+        transport: httpx.BaseTransport | None = None,
+        db_conn: sqlite3.Connection | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._call_times: deque[float] = deque()
+        client_kwargs: dict = {"timeout": 30.0}
+        if transport is not None:
+            client_kwargs["transport"] = transport
+        self._http = httpx.Client(**client_kwargs)
+        self._cache = AVCache(db_conn) if db_conn is not None else None
+
+    def _wait_for_rate_limit(self) -> None:
+        now = time.monotonic()
+        while self._call_times and (now - self._call_times[0]) > RATE_WINDOW:
+            self._call_times.popleft()
+
+        if len(self._call_times) >= RATE_LIMIT:
+            sleep_time = RATE_WINDOW - (now - self._call_times[0]) + 0.1
+            if sleep_time > 0:
+                logger.info("Rate limit reached, sleeping %.1fs", sleep_time)
+                time.sleep(sleep_time)
+
+        self._call_times.append(time.monotonic())
+
+    def _request(self, function: str, params: dict) -> dict:
+        self._wait_for_rate_limit()
+
+        params = {**params, "function": function, "apikey": self._api_key}
+
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                resp = self._http.get(AV_BASE_URL, params=params)
+                if resp.status_code in (429,) or resp.status_code >= 500:
+                    if attempt < MAX_RETRIES:
+                        wait = RETRY_BACKOFF * (2 ** attempt)
+                        logger.warning("%d from AV, retrying in %.1fs", resp.status_code, wait)
+                        time.sleep(wait)
+                        continue
+                    resp.raise_for_status()
+                resp.raise_for_status()
+                return resp.json()
+            except httpx.TransportError:
+                if attempt < MAX_RETRIES:
+                    wait = RETRY_BACKOFF * (2 ** attempt)
+                    logger.warning("Network error, retrying in %.1fs", wait)
+                    time.sleep(wait)
+                    continue
+                raise
+
+        raise RuntimeError("Exhausted retries")
+
+    def _cached_request(
+        self,
+        cache_key: str,
+        ttl_seconds: int,
+        function: str,
+        params: dict,
+        *,
+        bypass_cache: bool = False,
+    ) -> dict:
+        if self._cache is None:
+            return self._request(function, params)
+        return self._cache.get_or_fetch(
+            cache_key,
+            ttl_seconds,
+            lambda: self._request(function, params),
+            bypass_cache=bypass_cache,
+        )
+
+    # --- TTL constants (seconds) ---
+    TTL_7_DAYS = 7 * 24 * 3600
+    TTL_24H = 24 * 3600
+    TTL_1H = 3600
+    TTL_FOREVER = 100 * 365 * 24 * 3600
+
+    def get_overview(
+        self,
+        symbol: str,
+        *,
+        as_of: date | None = None,
+        bypass_cache: bool = False,
+    ) -> dict:
+        return self._cached_request(
+            f"overview:{symbol}",
+            self.TTL_7_DAYS,
+            "OVERVIEW",
+            {"symbol": symbol},
+            bypass_cache=bypass_cache,
+        )
+
+    def get_balance_sheet(
+        self,
+        symbol: str,
+        *,
+        as_of: date | None = None,
+        bypass_cache: bool = False,
+    ) -> dict:
+        return self._cached_request(
+            f"balance_sheet:{symbol}",
+            self.TTL_7_DAYS,
+            "BALANCE_SHEET",
+            {"symbol": symbol},
+            bypass_cache=bypass_cache,
+        )
+
+    def get_price_history(
+        self,
+        symbol: str,
+        *,
+        as_of: date | None = None,
+        bypass_cache: bool = False,
+    ) -> dict:
+        is_current = as_of is None or as_of >= date.today()
+        ttl = self.TTL_24H if is_current else self.TTL_FOREVER
+        cache_key = f"daily:{symbol}:{as_of or 'latest'}"
+        return self._cached_request(
+            cache_key,
+            ttl,
+            "TIME_SERIES_DAILY_ADJUSTED",
+            {"symbol": symbol, "outputsize": "full"},
+            bypass_cache=bypass_cache,
+        )
+
+    def get_options_chain(
+        self,
+        symbol: str,
+        *,
+        as_of: date | None = None,
+        bypass_cache: bool = False,
+    ) -> dict:
+        target_date = as_of or date.today()
+        is_today = target_date >= date.today()
+        ttl = self.TTL_24H if is_today else self.TTL_FOREVER
+        params: dict = {"symbol": symbol}
+        if as_of is not None:
+            params["date"] = as_of.isoformat()
+        return self._cached_request(
+            f"options:{symbol}:{target_date.isoformat()}",
+            ttl,
+            "HISTORICAL_OPTIONS",
+            params,
+            bypass_cache=bypass_cache,
+        )
+
+    def get_vix(
+        self,
+        *,
+        as_of: date | None = None,
+        bypass_cache: bool = False,
+    ) -> dict:
+        return self._cached_request(
+            "vix:daily",
+            self.TTL_24H,
+            "INDEX_DATA",
+            {"symbol": "VIX", "interval": "daily"},
+            bypass_cache=bypass_cache,
+        )
+
+    def get_earnings(
+        self,
+        symbol: str,
+        *,
+        as_of: date | None = None,
+        bypass_cache: bool = False,
+    ) -> dict:
+        return self._cached_request(
+            f"earnings:{symbol}",
+            self.TTL_FOREVER,
+            "EARNINGS",
+            {"symbol": symbol},
+            bypass_cache=bypass_cache,
+        )
+
+    def get_earnings_calendar(
+        self,
+        *,
+        symbol: str | None = None,
+        horizon: str = "3month",
+        bypass_cache: bool = False,
+    ) -> str:
+        self._wait_for_rate_limit()
+        params: dict = {
+            "function": "EARNINGS_CALENDAR",
+            "horizon": horizon,
+            "apikey": self._api_key,
+        }
+        if symbol is not None:
+            params["symbol"] = symbol
+        resp = self._http.get(AV_BASE_URL, params=params)
+        resp.raise_for_status()
+        return resp.text
+
+    def get_news_sentiment(
+        self,
+        symbol: str,
+        *,
+        as_of: date | None = None,
+        time_from: str | None = None,
+        time_to: str | None = None,
+        bypass_cache: bool = False,
+    ) -> dict:
+        params: dict = {"tickers": symbol, "sort": "LATEST", "limit": "1000"}
+        if time_from:
+            params["time_from"] = time_from
+        if time_to:
+            params["time_to"] = time_to
+
+        is_historical = time_to is not None
+        ttl = self.TTL_FOREVER if is_historical else self.TTL_1H
+        cache_key = f"news:{symbol}:{time_from or 'none'}:{time_to or 'latest'}"
+
+        return self._cached_request(
+            cache_key, ttl, "NEWS_SENTIMENT", params, bypass_cache=bypass_cache,
+        )

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -1,13 +1,7 @@
-"""Abstract base classes for market data providers.
-
-The provider layer defines the contract between the screening engine and
-whatever data source is in use. Each ABC declares the methods the engine
-needs. Concrete implementations (e.g., YahooFinanceProvider) fulfill these
-contracts. This lets us swap providers without touching business logic —
-just register a new subclass.
-"""
+"""Abstract base classes for market data providers."""
 
 from abc import ABC, abstractmethod
+from datetime import date
 
 import pandas as pd
 
@@ -16,69 +10,42 @@ from app.models.stock import StockProfile
 
 
 class MarketDataProvider(ABC):
-    """Provides stock fundamentals and price history."""
 
     @abstractmethod
-    def get_stock_info(self, symbol: str) -> StockProfile | None:
-        """Fetch fundamental data for a single symbol.
-
-        Returns None if the symbol is invalid or data is unavailable.
-        """
-        ...
+    def get_stock_info(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> StockProfile | None: ...
 
     @abstractmethod
     def get_price_history(
-        self, symbol: str, period: str = "3mo", interval: str = "1d"
-    ) -> pd.DataFrame:
-        """Fetch OHLCV price history.
-
-        Args:
-            symbol: Ticker symbol.
-            period: Lookback period (e.g., "3mo", "1y").
-            interval: Bar interval (e.g., "1d", "1h").
-
-        Returns:
-            DataFrame with columns: Open, High, Low, Close, Volume.
-            Index is a DatetimeIndex.
-        """
-        ...
+        self,
+        symbol: str,
+        period: str = "3mo",
+        interval: str = "1d",
+        *,
+        as_of: date | None = None,
+    ) -> pd.DataFrame: ...
 
     @abstractmethod
-    def get_sp500_symbols(self) -> list[str]:
-        """Return a list of current S&P 500 constituent symbols."""
-        ...
+    def get_sp500_symbols(self) -> list[str]: ...
 
 
 class OptionsDataProvider(ABC):
-    """Provides options chain data."""
 
     @abstractmethod
-    def get_expiry_dates(self, symbol: str) -> list[str]:
-        """Return available expiry dates for the symbol (ISO format strings)."""
-        ...
+    def get_expiry_dates(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> list[str]: ...
 
     @abstractmethod
-    def get_options_chain(self, symbol: str, expiry: str) -> OptionsChain:
-        """Fetch the full options chain for a symbol and expiry date.
-
-        Args:
-            symbol: Ticker symbol.
-            expiry: Expiry date as ISO string (YYYY-MM-DD).
-        """
-        ...
+    def get_options_chain(
+        self, symbol: str, expiry: str, *, as_of: date | None = None
+    ) -> OptionsChain: ...
 
 
 class NewsProvider(ABC):
-    """Provides recent news headlines for risk filtering."""
 
     @abstractmethod
     def get_recent_headlines(
-        self, symbol: str, hours: int = 24
-    ) -> list[Headline]:
-        """Fetch recent headlines for a symbol.
-
-        Args:
-            symbol: Ticker symbol.
-            hours: How far back to look (default 24h).
-        """
-        ...
+        self, symbol: str, hours: int = 24, *, as_of: date | None = None
+    ) -> list[Headline]: ...

--- a/app/providers/news.py
+++ b/app/providers/news.py
@@ -12,7 +12,7 @@ transparently — callers don't need to worry about pacing.
 import logging
 import time
 from collections import deque
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import httpx
 
@@ -52,7 +52,7 @@ class FinnhubNewsProvider(NewsProvider):
         self._call_times.append(time.monotonic())
 
     def get_recent_headlines(
-        self, symbol: str, hours: int = 24
+        self, symbol: str, hours: int = 24, *, as_of: date | None = None
     ) -> list[Headline]:
         if not self._api_key:
             logger.debug("No Finnhub API key configured, skipping news check")

--- a/app/providers/yahoo.py
+++ b/app/providers/yahoo.py
@@ -38,7 +38,9 @@ class YahooFinanceProvider(MarketDataProvider, OptionsDataProvider):
     the same Ticker object.
     """
 
-    def get_stock_info(self, symbol: str) -> StockProfile | None:
+    def get_stock_info(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> StockProfile | None:
         try:
             ticker = yf.Ticker(symbol)
             info = ticker.info
@@ -74,7 +76,12 @@ class YahooFinanceProvider(MarketDataProvider, OptionsDataProvider):
             return None
 
     def get_price_history(
-        self, symbol: str, period: str = "3mo", interval: str = "1d"
+        self,
+        symbol: str,
+        period: str = "3mo",
+        interval: str = "1d",
+        *,
+        as_of: date | None = None,
     ) -> pd.DataFrame:
         ticker = yf.Ticker(symbol)
         hist = ticker.history(period=period, interval=interval)
@@ -93,11 +100,15 @@ class YahooFinanceProvider(MarketDataProvider, OptionsDataProvider):
             logger.warning("Failed to load S&P 500 list from file", exc_info=True)
             return _FALLBACK_SYMBOLS
 
-    def get_expiry_dates(self, symbol: str) -> list[str]:
+    def get_expiry_dates(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> list[str]:
         ticker = yf.Ticker(symbol)
         return list(ticker.options)
 
-    def get_options_chain(self, symbol: str, expiry: str) -> OptionsChain:
+    def get_options_chain(
+        self, symbol: str, expiry: str, *, as_of: date | None = None
+    ) -> OptionsChain:
         ticker = yf.Ticker(symbol)
         chain = ticker.option_chain(expiry)
         expiry_date = date.fromisoformat(expiry)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas>=3.0.1",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",
+    "ruff>=0.15.12",
     "uvicorn>=0.41.0",
     "yfinance>=1.2.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,31 @@
-"""Shared test fixtures.
+"""Shared test fixtures."""
 
-Provides mock providers with deterministic data so tests don't hit
-real APIs. Each fixture returns a provider pre-loaded with sample
-StockProfile data covering various filter edge cases.
-"""
+from datetime import date
 
 import pandas as pd
 import pytest
 
-from app.models.option import OptionsChain
 from app.models.stock import StockProfile
 from app.providers.base import MarketDataProvider
 
 
 class MockMarketDataProvider(MarketDataProvider):
-    """In-memory provider for testing. Stocks are loaded via a dict."""
 
     def __init__(self, stocks: dict[str, StockProfile]) -> None:
         self._stocks = stocks
 
-    def get_stock_info(self, symbol: str) -> StockProfile | None:
+    def get_stock_info(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> StockProfile | None:
         return self._stocks.get(symbol)
 
     def get_price_history(
-        self, symbol: str, period: str = "3mo", interval: str = "1d"
+        self,
+        symbol: str,
+        period: str = "3mo",
+        interval: str = "1d",
+        *,
+        as_of: date | None = None,
     ) -> pd.DataFrame:
         return pd.DataFrame()
 

--- a/tests/fixtures/av/historical_options_aapl.json
+++ b/tests/fixtures/av/historical_options_aapl.json
@@ -1,0 +1,50 @@
+{
+    "endpoint": "Historical Options",
+    "message": "success",
+    "data": [
+        {
+            "contractID": "AAPL260620P00200000",
+            "symbol": "AAPL",
+            "expiration": "2026-06-20",
+            "strike": "200.00",
+            "type": "put",
+            "last": "2.60",
+            "mark": "2.60",
+            "bid": "2.50",
+            "bid_size": "10",
+            "ask": "2.70",
+            "ask_size": "15",
+            "volume": "1500",
+            "open_interest": "8000",
+            "date": "2026-05-14",
+            "implied_volatility": "0.25000",
+            "delta": "-0.22000",
+            "gamma": "0.01500",
+            "theta": "-0.05000",
+            "vega": "0.10000",
+            "rho": "-0.01000"
+        },
+        {
+            "contractID": "AAPL260620C00200000",
+            "symbol": "AAPL",
+            "expiration": "2026-06-20",
+            "strike": "200.00",
+            "type": "call",
+            "last": "30.00",
+            "mark": "30.10",
+            "bid": "29.90",
+            "bid_size": "20",
+            "ask": "30.30",
+            "ask_size": "25",
+            "volume": "3000",
+            "open_interest": "12000",
+            "date": "2026-05-14",
+            "implied_volatility": "0.24000",
+            "delta": "0.78000",
+            "gamma": "0.01500",
+            "theta": "-0.06000",
+            "vega": "0.10000",
+            "rho": "0.02000"
+        }
+    ]
+}

--- a/tests/fixtures/av/news_sentiment_aapl.json
+++ b/tests/fixtures/av/news_sentiment_aapl.json
@@ -1,0 +1,43 @@
+{
+    "items": "2",
+    "sentiment_score_definition": "x <= -0.35: Bearish; -0.35 < x <= -0.15: Somewhat-Bearish; -0.15 < x < 0.15: Neutral; 0.15 <= x < 0.35: Somewhat_Bullish; x >= 0.35: Bullish",
+    "relevance_score_definition": "0 < x <= 1, with a higher score indicating higher relevance.",
+    "feed": [
+        {
+            "title": "Apple reports record quarterly earnings",
+            "url": "https://example.com/article1",
+            "time_published": "20260514T100000",
+            "authors": ["Test Author"],
+            "summary": "Apple reported strong earnings.",
+            "source": "TestNews",
+            "overall_sentiment_score": 0.35,
+            "overall_sentiment_label": "Bullish",
+            "ticker_sentiment": [
+                {
+                    "ticker": "AAPL",
+                    "relevance_score": "0.90",
+                    "ticker_sentiment_score": "0.40",
+                    "ticker_sentiment_label": "Bullish"
+                }
+            ]
+        },
+        {
+            "title": "Tech sector faces regulatory pressure",
+            "url": "https://example.com/article2",
+            "time_published": "20260514T080000",
+            "authors": ["Another Author"],
+            "summary": "Regulators are investigating.",
+            "source": "OtherNews",
+            "overall_sentiment_score": -0.40,
+            "overall_sentiment_label": "Bearish",
+            "ticker_sentiment": [
+                {
+                    "ticker": "AAPL",
+                    "relevance_score": "0.70",
+                    "ticker_sentiment_score": "-0.38",
+                    "ticker_sentiment_label": "Bearish"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/av/overview_aapl.json
+++ b/tests/fixtures/av/overview_aapl.json
@@ -1,0 +1,19 @@
+{
+    "Symbol": "AAPL",
+    "AssetType": "Common Stock",
+    "Name": "Apple Inc",
+    "Exchange": "NASDAQ",
+    "Currency": "USD",
+    "Country": "USA",
+    "Sector": "TECHNOLOGY",
+    "Industry": "ELECTRONIC COMPUTERS",
+    "MarketCapitalization": "3200000000000",
+    "EBITDA": "130000000000",
+    "PERatio": "32.5",
+    "ReturnOnEquityTTM": "1.50",
+    "Beta": "1.25",
+    "52WeekHigh": "260.0",
+    "52WeekLow": "170.0",
+    "50DayMovingAverage": "225.0",
+    "200DayMovingAverage": "210.0"
+}

--- a/tests/fixtures/av/time_series_daily_aapl.json
+++ b/tests/fixtures/av/time_series_daily_aapl.json
@@ -1,0 +1,39 @@
+{
+    "Meta Data": {
+        "1. Information": "Daily Time Series with Splits and Dividend Events",
+        "2. Symbol": "AAPL",
+        "3. Last Refreshed": "2026-05-14"
+    },
+    "Time Series (Daily)": {
+        "2026-05-14": {
+            "1. open": "230.00",
+            "2. high": "235.00",
+            "3. low": "228.00",
+            "4. close": "233.50",
+            "5. adjusted close": "233.50",
+            "6. volume": "45000000",
+            "7. dividend amount": "0.0000",
+            "8. split coefficient": "1.0"
+        },
+        "2026-05-13": {
+            "1. open": "228.00",
+            "2. high": "231.00",
+            "3. low": "226.50",
+            "4. close": "230.00",
+            "5. adjusted close": "230.00",
+            "6. volume": "38000000",
+            "7. dividend amount": "0.0000",
+            "8. split coefficient": "1.0"
+        },
+        "2026-05-12": {
+            "1. open": "225.00",
+            "2. high": "229.00",
+            "3. low": "224.00",
+            "4. close": "228.00",
+            "5. adjusted close": "228.00",
+            "6. volume": "42000000",
+            "7. dividend amount": "0.0000",
+            "8. split coefficient": "1.0"
+        }
+    }
+}

--- a/tests/test_as_of_plumbing.py
+++ b/tests/test_as_of_plumbing.py
@@ -1,0 +1,141 @@
+"""Tests for as_of plumbing through ABCs and engine functions."""
+
+from datetime import date, timedelta
+
+import pandas as pd
+
+from app.engine.pipeline import run_scan
+from app.models.option import Headline, OptionContract, OptionsChain
+from app.models.stock import StockProfile
+from app.providers.base import MarketDataProvider, NewsProvider, OptionsDataProvider
+from tests.conftest import make_stock
+
+
+class AsOfTrackingMarketProvider(MarketDataProvider):
+    """Tracks which as_of values were passed to each method."""
+
+    def __init__(self, stocks: dict[str, StockProfile]) -> None:
+        self._stocks = stocks
+        self.as_of_calls: list[tuple[str, date | None]] = []
+
+    def get_stock_info(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> StockProfile | None:
+        self.as_of_calls.append(("get_stock_info", as_of))
+        return self._stocks.get(symbol)
+
+    def get_price_history(
+        self,
+        symbol: str,
+        period: str = "3mo",
+        interval: str = "1d",
+        *,
+        as_of: date | None = None,
+    ) -> pd.DataFrame:
+        self.as_of_calls.append(("get_price_history", as_of))
+        prices = [150 - i for i in range(10)] + [140] + [140 + i for i in range(10)]
+        return pd.DataFrame({
+            "Open": prices,
+            "High": [p + 1 for p in prices],
+            "Low": prices,
+            "Close": [p + 0.5 for p in prices],
+            "Volume": [1000000] * len(prices),
+        })
+
+    def get_sp500_symbols(self) -> list[str]:
+        return list(self._stocks.keys())
+
+
+class AsOfTrackingOptionsProvider(OptionsDataProvider):
+    def __init__(self) -> None:
+        self.as_of_calls: list[tuple[str, date | None]] = []
+
+    def get_expiry_dates(
+        self, symbol: str, *, as_of: date | None = None
+    ) -> list[str]:
+        self.as_of_calls.append(("get_expiry_dates", as_of))
+        target = (as_of or date.today()) + timedelta(days=17)
+        return [target.isoformat()]
+
+    def get_options_chain(
+        self, symbol: str, expiry: str, *, as_of: date | None = None
+    ) -> OptionsChain:
+        self.as_of_calls.append(("get_options_chain", as_of))
+        expiry_date = date.fromisoformat(expiry)
+        put = OptionContract(
+            symbol=symbol,
+            expiry=expiry_date,
+            strike=135.0,
+            option_type="put",
+            bid=1.40,
+            ask=1.60,
+            last_price=1.50,
+            delta=-0.22,
+            theta=-0.05,
+            implied_volatility=0.30,
+            open_interest=5000,
+            volume=500,
+        )
+        return OptionsChain(symbol=symbol, expiry=expiry_date, puts=[put], calls=[put])
+
+
+class AsOfTrackingNewsProvider(NewsProvider):
+    def __init__(self) -> None:
+        self.as_of_calls: list[tuple[str, date | None]] = []
+
+    def get_recent_headlines(
+        self, symbol: str, hours: int = 24, *, as_of: date | None = None
+    ) -> list[Headline]:
+        self.as_of_calls.append(("get_recent_headlines", as_of))
+        return []
+
+
+class TestAsOfPlumbing:
+    def test_run_scan_threads_as_of_through_all_providers(self) -> None:
+        stock = make_stock(symbol="TEST", current_price=150.0)
+        market = AsOfTrackingMarketProvider({"TEST": stock})
+        options = AsOfTrackingOptionsProvider()
+        news = AsOfTrackingNewsProvider()
+
+        target_date = date(2026, 1, 5)
+        run_scan(
+            market_provider=market,
+            options_provider=options,
+            news_provider=news,
+            symbols=["TEST"],
+            as_of=target_date,
+        )
+
+        for method, as_of_val in market.as_of_calls:
+            assert as_of_val == target_date, (
+                f"MarketProvider.{method} received as_of={as_of_val}, "
+                f"expected {target_date}"
+            )
+
+        for method, as_of_val in options.as_of_calls:
+            assert as_of_val == target_date, (
+                f"OptionsProvider.{method} received as_of={as_of_val}, "
+                f"expected {target_date}"
+            )
+
+        for method, as_of_val in news.as_of_calls:
+            assert as_of_val == target_date, (
+                f"NewsProvider.{method} received as_of={as_of_val}, "
+                f"expected {target_date}"
+            )
+
+    def test_run_scan_none_as_of_passes_none(self) -> None:
+        stock = make_stock(symbol="TEST", current_price=150.0)
+        market = AsOfTrackingMarketProvider({"TEST": stock})
+        options = AsOfTrackingOptionsProvider()
+
+        run_scan(
+            market_provider=market,
+            options_provider=options,
+            symbols=["TEST"],
+        )
+
+        for method, as_of_val in market.as_of_calls:
+            assert as_of_val is None, (
+                f"MarketProvider.{method} received as_of={as_of_val}, expected None"
+            )

--- a/tests/test_av_adapters.py
+++ b/tests/test_av_adapters.py
@@ -1,0 +1,123 @@
+"""Tests for AV adapter classes — thin translation layer over AVClient."""
+
+import json
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import httpx
+
+from app.providers.av_client import AVClient
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "av"
+
+
+def _make_av_client(fixture_map: dict[str, str | dict]) -> AVClient:
+    """Create an AVClient backed by MockTransport returning fixtures by function name."""
+    def transport(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        for function_name, fixture in fixture_map.items():
+            if f"function={function_name}" in url:
+                if isinstance(fixture, str):
+                    data = json.loads((FIXTURES_DIR / fixture).read_text())
+                else:
+                    data = fixture
+                return httpx.Response(200, json=data)
+        return httpx.Response(404, text="not found")
+
+    conn = sqlite3.connect(":memory:")
+    return AVClient(
+        api_key="test-key",
+        transport=httpx.MockTransport(transport),
+        db_conn=conn,
+    )
+
+
+class TestAVMarketDataAdapter:
+    def test_get_stock_info_returns_profile_with_beta(self) -> None:
+        from app.providers.av_adapters import AVMarketDataAdapter
+
+        client = _make_av_client({
+            "OVERVIEW": "overview_aapl.json",
+            "BALANCE_SHEET": {
+                "symbol": "AAPL",
+                "quarterlyReports": [
+                    {
+                        "fiscalDateEnding": "2026-03-31",
+                        "shortLongTermDebtTotal": "120000000000",
+                    }
+                ],
+            },
+        })
+        adapter = AVMarketDataAdapter(client)
+
+        profile = adapter.get_stock_info("AAPL")
+        assert profile is not None
+        assert profile.symbol == "AAPL"
+        assert profile.name == "Apple Inc"
+        assert profile.sector == "TECHNOLOGY"
+        assert profile.market_cap == 3_200_000_000_000
+        assert profile.roe == 1.50
+        assert profile.beta == 1.25
+        assert profile.current_price > 0
+
+    def test_get_price_history_returns_dataframe(self) -> None:
+        from app.providers.av_adapters import AVMarketDataAdapter
+
+        client = _make_av_client({
+            "TIME_SERIES_DAILY_ADJUSTED": "time_series_daily_aapl.json",
+        })
+        adapter = AVMarketDataAdapter(client)
+
+        df = adapter.get_price_history("AAPL")
+        assert not df.empty
+        assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+        assert len(df) == 3
+        assert df["Close"].iloc[-1] == 233.50
+
+
+class TestAVOptionsAdapter:
+    def test_get_options_chain_returns_chain_with_greeks(self) -> None:
+        from app.providers.av_adapters import AVOptionsAdapter
+
+        client = _make_av_client({
+            "HISTORICAL_OPTIONS": "historical_options_aapl.json",
+        })
+        adapter = AVOptionsAdapter(client)
+
+        chain = adapter.get_options_chain("AAPL", "2026-06-20")
+        assert chain.symbol == "AAPL"
+        assert chain.expiry == date(2026, 6, 20)
+        assert len(chain.puts) == 1
+        assert len(chain.calls) == 1
+        assert chain.puts[0].delta == -0.22
+        assert chain.puts[0].strike == 200.0
+        assert chain.puts[0].open_interest == 8000
+        assert chain.calls[0].delta == 0.78
+
+    def test_get_expiry_dates_returns_unique_sorted(self) -> None:
+        from app.providers.av_adapters import AVOptionsAdapter
+
+        client = _make_av_client({
+            "HISTORICAL_OPTIONS": "historical_options_aapl.json",
+        })
+        adapter = AVOptionsAdapter(client)
+
+        expiries = adapter.get_expiry_dates("AAPL")
+        assert expiries == ["2026-06-20"]
+
+
+class TestAVNewsAdapter:
+    def test_get_recent_headlines_returns_headlines(self) -> None:
+        from app.providers.av_adapters import AVNewsAdapter
+
+        client = _make_av_client({
+            "NEWS_SENTIMENT": "news_sentiment_aapl.json",
+        })
+        adapter = AVNewsAdapter(client)
+
+        headlines = adapter.get_recent_headlines("AAPL")
+        assert len(headlines) == 2
+        assert headlines[0].title == "Apple reports record quarterly earnings"
+        assert headlines[0].source == "TestNews"
+        assert headlines[1].title == "Tech sector faces regulatory pressure"

--- a/tests/test_av_cache.py
+++ b/tests/test_av_cache.py
@@ -1,0 +1,187 @@
+"""Tests for the AVCache — SQLite-backed cache with TTL and stale-on-error."""
+
+import sqlite3
+import time
+from unittest.mock import patch
+
+from app.providers.av_cache import AVCache
+
+
+def _make_cache() -> AVCache:
+    conn = sqlite3.connect(":memory:")
+    return AVCache(conn)
+
+
+class TestCacheMiss:
+    def test_miss_calls_fetcher_and_stores(self) -> None:
+        cache = _make_cache()
+        call_count = 0
+
+        def fetcher() -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"symbol": "AAPL", "Beta": "1.2"}
+
+        result = cache.get_or_fetch("overview:AAPL", ttl_seconds=3600, fetcher=fetcher)
+        assert result == {"symbol": "AAPL", "Beta": "1.2"}
+        assert call_count == 1
+
+        result2 = cache.get_or_fetch("overview:AAPL", ttl_seconds=3600, fetcher=fetcher)
+        assert result2 == {"symbol": "AAPL", "Beta": "1.2"}
+        assert call_count == 1  # fetcher not called again
+
+
+class TestCacheHit:
+    def test_hit_within_ttl_skips_fetcher(self) -> None:
+        cache = _make_cache()
+        call_count = 0
+
+        def fetcher() -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"price": 150.0}
+
+        cache.get_or_fetch("price:AAPL", ttl_seconds=3600, fetcher=fetcher)
+        assert call_count == 1
+
+        result = cache.get_or_fetch("price:AAPL", ttl_seconds=3600, fetcher=fetcher)
+        assert result == {"price": 150.0}
+        assert call_count == 1
+
+
+class TestCacheExpiry:
+    def test_expired_entry_re_fetches(self) -> None:
+        cache = _make_cache()
+        call_count = 0
+        current_value = {"v": 1}
+
+        def fetcher() -> dict:
+            nonlocal call_count
+            call_count += 1
+            return current_value
+
+        now = time.time()
+        with patch("app.providers.av_cache.time") as mock_time:
+            mock_time.time.return_value = now
+            cache.get_or_fetch("key", ttl_seconds=60, fetcher=fetcher)
+            assert call_count == 1
+
+            mock_time.time.return_value = now + 61
+            current_value = {"v": 2}
+            result = cache.get_or_fetch("key", ttl_seconds=60, fetcher=fetcher)
+            assert result == {"v": 2}
+            assert call_count == 2
+
+
+class TestStaleOnError:
+    def test_serves_stale_on_fetcher_failure(self, caplog) -> None:
+        cache = _make_cache()
+
+        cache.get_or_fetch("key", ttl_seconds=60, fetcher=lambda: {"v": 1})
+
+        now = time.time()
+        with patch("app.providers.av_cache.time") as mock_time:
+            mock_time.time.return_value = now + 120
+
+            def failing_fetcher():
+                raise ConnectionError("AV down")
+
+            import logging
+            with caplog.at_level(logging.WARNING, logger="app.providers.av_cache"):
+                result = cache.get_or_fetch("key", ttl_seconds=60, fetcher=failing_fetcher)
+
+            assert result == {"v": 1}
+            assert "stale" in caplog.text.lower()
+
+    def test_no_stale_entry_propagates_error(self) -> None:
+        cache = _make_cache()
+
+        def failing_fetcher():
+            raise ConnectionError("AV down")
+
+        try:
+            cache.get_or_fetch("key", ttl_seconds=60, fetcher=failing_fetcher)
+            assert False, "Should have raised"
+        except ConnectionError:
+            pass
+
+
+class TestBypassCache:
+    def test_bypass_always_calls_fetcher(self) -> None:
+        cache = _make_cache()
+        call_count = 0
+
+        def fetcher() -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"v": call_count}
+
+        cache.get_or_fetch("key", ttl_seconds=3600, fetcher=fetcher)
+        assert call_count == 1
+
+        result = cache.get_or_fetch(
+            "key", ttl_seconds=3600, fetcher=fetcher, bypass_cache=True
+        )
+        assert call_count == 2
+        assert result == {"v": 2}
+
+        result3 = cache.get_or_fetch("key", ttl_seconds=3600, fetcher=fetcher)
+        assert call_count == 2  # normal hit uses updated cache
+        assert result3 == {"v": 2}
+
+
+class TestOptionsChainCache:
+    def test_store_and_retrieve_chain(self) -> None:
+        cache = _make_cache()
+        contracts = [
+            {
+                "symbol": "AAPL",
+                "expiration": "2026-06-20",
+                "strike": 200.0,
+                "option_type": "put",
+                "bid": 2.50,
+                "ask": 2.70,
+                "last_price": 2.60,
+                "mark": 2.60,
+                "volume": 1500,
+                "open_interest": 8000,
+                "implied_volatility": 0.25,
+                "delta": -0.22,
+                "gamma": 0.015,
+                "theta": -0.05,
+                "vega": 0.10,
+                "rho": -0.01,
+            },
+            {
+                "symbol": "AAPL",
+                "expiration": "2026-06-20",
+                "strike": 195.0,
+                "option_type": "put",
+                "bid": 1.80,
+                "ask": 2.00,
+                "last_price": 1.90,
+                "mark": 1.90,
+                "volume": 900,
+                "open_interest": 5000,
+                "implied_volatility": 0.23,
+                "delta": -0.18,
+                "gamma": 0.012,
+                "theta": -0.04,
+                "vega": 0.08,
+                "rho": -0.008,
+            },
+        ]
+
+        cache.store_options_chain("AAPL", "2026-05-14", contracts)
+        result = cache.get_options_chain("AAPL", "2026-05-14")
+
+        assert len(result) == 2
+        assert result[0]["strike"] == 195.0
+        assert result[0]["delta"] == -0.18
+        assert result[1]["strike"] == 200.0
+        assert result[1]["delta"] == -0.22
+
+    def test_get_missing_chain_returns_none(self) -> None:
+        cache = _make_cache()
+        result = cache.get_options_chain("AAPL", "2026-05-14")
+        assert result is None

--- a/tests/test_av_client.py
+++ b/tests/test_av_client.py
@@ -1,0 +1,189 @@
+"""Tests for AVClient — rate limiter, retry, and cache integration."""
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+from app.providers.av_client import AVClient
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "av"
+
+
+def _noop_transport(*_args, **_kwargs) -> httpx.Response:
+    return httpx.Response(200, json={"result": "ok"})
+
+
+def _make_client(
+    transport: httpx.MockTransport | None = None,
+    api_key: str = "test-key",
+) -> AVClient:
+    if transport is None:
+        transport = httpx.MockTransport(_noop_transport)
+    return AVClient(api_key=api_key, transport=transport)
+
+
+class TestRateLimiter:
+    def test_paces_beyond_75_per_minute(self) -> None:
+        request_times: list[float] = []
+
+        def tracking_transport(request: httpx.Request) -> httpx.Response:
+            request_times.append(time.monotonic())
+            return httpx.Response(200, json={"result": "ok"})
+
+        client = _make_client(httpx.MockTransport(tracking_transport))
+
+        now = time.monotonic()
+        with patch("app.providers.av_client.time") as mock_time:
+            mock_time.monotonic.return_value = now
+            mock_time.sleep = time.sleep
+
+            for i in range(76):
+                mock_time.monotonic.return_value = now + i * 0.01
+                client._request("OVERVIEW", {"symbol": "AAPL"})
+
+            # The 76th call should have been delayed
+            assert len(request_times) == 76
+
+
+class TestRetry:
+    def test_retries_on_429(self) -> None:
+        attempts = []
+
+        def transport(request: httpx.Request) -> httpx.Response:
+            attempts.append(1)
+            if len(attempts) < 3:
+                return httpx.Response(429, text="rate limited")
+            return httpx.Response(200, json={"ok": True})
+
+        client = _make_client(httpx.MockTransport(transport))
+        with patch("app.providers.av_client.time") as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            mock_time.sleep = lambda _: None
+            result = client._request("OVERVIEW", {"symbol": "AAPL"})
+
+        assert result == {"ok": True}
+        assert len(attempts) == 3
+
+    def test_retries_on_500(self) -> None:
+        attempts = []
+
+        def transport(request: httpx.Request) -> httpx.Response:
+            attempts.append(1)
+            if len(attempts) < 2:
+                return httpx.Response(500, text="server error")
+            return httpx.Response(200, json={"ok": True})
+
+        client = _make_client(httpx.MockTransport(transport))
+        with patch("app.providers.av_client.time") as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            mock_time.sleep = lambda _: None
+            result = client._request("OVERVIEW", {"symbol": "AAPL"})
+
+        assert result == {"ok": True}
+        assert len(attempts) == 2
+
+    def test_retries_on_network_error(self) -> None:
+        attempts = []
+
+        def transport(request: httpx.Request) -> httpx.Response:
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise httpx.ConnectError("connection refused")
+            return httpx.Response(200, json={"ok": True})
+
+        client = _make_client(httpx.MockTransport(transport))
+        with patch("app.providers.av_client.time") as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            mock_time.sleep = lambda _: None
+            result = client._request("OVERVIEW", {"symbol": "AAPL"})
+
+        assert result == {"ok": True}
+        assert len(attempts) == 2
+
+
+class TestGetOverview:
+    def test_returns_parsed_data_with_cache(self) -> None:
+        fixture = json.loads((FIXTURES_DIR / "overview_aapl.json").read_text())
+        call_count = 0
+
+        def transport(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            assert "function=OVERVIEW" in str(request.url)
+            assert "symbol=AAPL" in str(request.url)
+            return httpx.Response(200, json=fixture)
+
+        conn = sqlite3.connect(":memory:")
+        client = AVClient(
+            api_key="test-key",
+            transport=httpx.MockTransport(transport),
+            db_conn=conn,
+        )
+
+        result = client.get_overview("AAPL")
+        assert result["Symbol"] == "AAPL"
+        assert result["Beta"] == "1.25"
+        assert call_count == 1
+
+        result2 = client.get_overview("AAPL")
+        assert result2["Symbol"] == "AAPL"
+        assert call_count == 1  # cache hit
+
+
+class TestGetOptionsChain:
+    def test_returns_parsed_chain_with_typed_cache(self) -> None:
+        fixture = json.loads(
+            (FIXTURES_DIR / "historical_options_aapl.json").read_text()
+        )
+        call_count = 0
+
+        def transport(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            assert "function=HISTORICAL_OPTIONS" in str(request.url)
+            return httpx.Response(200, json=fixture)
+
+        conn = sqlite3.connect(":memory:")
+        client = AVClient(
+            api_key="test-key",
+            transport=httpx.MockTransport(transport),
+            db_conn=conn,
+        )
+
+        from datetime import date
+        result = client.get_options_chain("AAPL", as_of=date(2026, 5, 14))
+        assert result["data"][0]["symbol"] == "AAPL"
+        assert result["data"][0]["delta"] == "-0.22000"
+        assert call_count == 1
+
+        client.get_options_chain("AAPL", as_of=date(2026, 5, 14))
+        assert call_count == 1  # cache hit
+
+
+class TestGetNewsSentiment:
+    def test_returns_parsed_articles(self) -> None:
+        fixture = json.loads(
+            (FIXTURES_DIR / "news_sentiment_aapl.json").read_text()
+        )
+
+        def transport(request: httpx.Request) -> httpx.Response:
+            assert "function=NEWS_SENTIMENT" in str(request.url)
+            assert "tickers=AAPL" in str(request.url)
+            return httpx.Response(200, json=fixture)
+
+        conn = sqlite3.connect(":memory:")
+        client = AVClient(
+            api_key="test-key",
+            transport=httpx.MockTransport(transport),
+            db_conn=conn,
+        )
+
+        result = client.get_news_sentiment("AAPL")
+        assert len(result["feed"]) == 2
+        assert result["feed"][0]["ticker_sentiment"][0]["ticker"] == "AAPL"
+        sentiment_score = result["feed"][0]["ticker_sentiment"][0]["ticker_sentiment_score"]
+        assert float(sentiment_score) > 0

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -2,9 +2,9 @@
 
 from datetime import date
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
-from app.backup import backup_db_to_s3, run_backup
+from app.backup import backup_db_to_s3, restore_db_from_s3, run_backup
 
 FAKE_TODAY = date(2026, 4, 5)
 
@@ -45,9 +45,9 @@ class TestBackupUpload:
             aws_access_key_id="AKID",
             aws_secret_access_key="SECRET",
         )
-        mock_client.upload_file.assert_called_once_with(
-            str(db_file), "test-bucket", "backups/screener-2026-04-05.db"
-        )
+        upload_calls = mock_client.upload_file.call_args_list
+        assert call(str(db_file), "test-bucket", "backups/screener-2026-04-05.db") in upload_calls
+        assert call(str(db_file), "test-bucket", "backups/screener-latest.db") in upload_calls
 
 
 class TestBackupPrune:
@@ -140,6 +140,73 @@ class TestRunBackup:
 
         mock_backup.assert_not_called()
         assert "skipped" in caplog.text.lower()
+
+
+class TestImmortalLatest:
+    """backup_db_to_s3 also uploads screener-latest.db."""
+
+    @patch("app.backup._today", return_value=FAKE_TODAY)
+    @patch("app.backup.boto3")
+    def test_uploads_latest_alongside_dated(self, mock_boto3, _mock_today, tmp_path):
+        db_file = tmp_path / "screener.db"
+        db_file.write_text("fake-db-content")
+
+        mock_client = _mock_s3()
+        mock_boto3.client.return_value = mock_client
+
+        backup_db_to_s3(
+            db_path=str(db_file),
+            bucket="test-bucket",
+            region="us-east-1",
+        )
+
+        upload_calls = mock_client.upload_file.call_args_list
+        keys = [c.args[2] for c in upload_calls]
+        assert "backups/screener-2026-04-05.db" in keys
+        assert "backups/screener-latest.db" in keys
+
+    @patch("app.backup._today", return_value=FAKE_TODAY)
+    @patch("app.backup.boto3")
+    def test_prune_skips_latest(self, mock_boto3, _mock_today, tmp_path):
+        db_file = tmp_path / "screener.db"
+        db_file.write_text("fake-db-content")
+
+        mock_client = _mock_s3(list_contents=[
+            {"Key": "backups/screener-2026-02-01.db"},  # old — delete
+            {"Key": "backups/screener-latest.db"},  # immortal — keep
+            {"Key": "backups/screener-2026-04-05.db"},  # today — keep
+        ])
+        mock_boto3.client.return_value = mock_client
+
+        backup_db_to_s3(
+            db_path=str(db_file),
+            bucket="test-bucket",
+            region="us-east-1",
+            retention_days=30,
+        )
+
+        deleted = mock_client.delete_objects.call_args[1]["Delete"]["Objects"]
+        deleted_keys = [d["Key"] for d in deleted]
+        assert "backups/screener-latest.db" not in deleted_keys
+        assert "backups/screener-2026-02-01.db" in deleted_keys
+
+
+class TestRestoreFromS3:
+    @patch("app.backup.boto3")
+    def test_downloads_latest_db(self, mock_boto3, tmp_path):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        target = str(tmp_path / "screener.db")
+        restore_db_from_s3(
+            db_path=target,
+            bucket="test-bucket",
+            region="us-east-1",
+        )
+
+        mock_client.download_file.assert_called_once_with(
+            "test-bucket", "backups/screener-latest.db", target
+        )
 
 
 class TestCronIntegration:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -48,6 +48,7 @@ class TestGetConnection:
             "market_risk_elevated",
             "vix_level",
             "spy_price",
+            "backtest_run_id",
         }
 
         # snapshot_trades table exists with expected columns

--- a/tests/test_options_screener.py
+++ b/tests/test_options_screener.py
@@ -47,14 +47,14 @@ class MockOptionsProvider(OptionsDataProvider):
     def __init__(self, chains: dict[str, OptionsChain]) -> None:
         self._chains = chains
 
-    def get_expiry_dates(self, symbol: str) -> list[str]:
+    def get_expiry_dates(self, symbol: str, *, as_of=None) -> list[str]:
         return [
             chain.expiry.isoformat()
             for chain in self._chains.values()
             if chain.symbol == symbol
         ]
 
-    def get_options_chain(self, symbol: str, expiry: str) -> OptionsChain:
+    def get_options_chain(self, symbol: str, expiry: str, *, as_of=None) -> OptionsChain:
         return self._chains[expiry]
 
 
@@ -65,11 +65,11 @@ class MockMarketProvider(MarketDataProvider):
         self._stock = stock
         self._support = support_price
 
-    def get_stock_info(self, symbol: str) -> StockProfile | None:
+    def get_stock_info(self, symbol: str, *, as_of=None) -> StockProfile | None:
         return self._stock if symbol == self._stock.symbol else None
 
     def get_price_history(
-        self, symbol: str, period: str = "3mo", interval: str = "1d"
+        self, symbol: str, period: str = "3mo", interval: str = "1d", *, as_of=None
     ) -> pd.DataFrame:
         # Create a price history with a clear dip at support_price
         prices = (

--- a/tests/test_report_api.py
+++ b/tests/test_report_api.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.db import get_connection, insert_snapshot, insert_trades, update_trade_outcome
+from app.db import insert_snapshot, insert_trades, update_trade_outcome
 
 
 SAMPLE_SNAPSHOT = {

--- a/tests/test_risk_filter.py
+++ b/tests/test_risk_filter.py
@@ -8,7 +8,6 @@ from app.engine.risk_filter import (
     apply_risk_filters,
 )
 from app.models.option import Headline
-from app.models.stock import StockProfile
 from app.providers.base import NewsProvider
 from tests.conftest import MockMarketDataProvider, make_stock
 
@@ -19,7 +18,9 @@ class MockNewsProvider(NewsProvider):
     def __init__(self, headlines: dict[str, list[Headline]]) -> None:
         self._headlines = headlines
 
-    def get_recent_headlines(self, symbol: str, hours: int = 24) -> list[Headline]:
+    def get_recent_headlines(
+        self, symbol: str, hours: int = 24, *, as_of=None
+    ) -> list[Headline]:
         return self._headlines.get(symbol, [])
 
 

--- a/tests/test_safety_score.py
+++ b/tests/test_safety_score.py
@@ -11,7 +11,6 @@ from app.engine.safety_score import (
 )
 from app.models.market import MarketRiskStatus
 from app.models.option import ScreenedTrade
-from app.models.stock import StockProfile
 from tests.conftest import make_stock
 
 

--- a/tests/test_schema_additions.py
+++ b/tests/test_schema_additions.py
@@ -1,0 +1,71 @@
+"""Tests for schema additions: backtest_runs table and backtest_run_id on snapshots."""
+
+import sqlite3
+
+from app.db import _create_schema, insert_snapshot
+
+
+class TestBacktestRunsSchema:
+    def test_backtest_runs_table_exists(self) -> None:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        _create_schema(conn)
+
+        conn.execute("""
+            INSERT INTO backtest_runs (name, started_at, date_range_start, date_range_end,
+                                       scan_frequency, strategy_params)
+            VALUES ('test-run', '2026-05-14T10:00:00', '2025-05-01', '2026-05-01',
+                    'weekly', '{"max_trades": 15}')
+        """)
+        conn.commit()
+
+        row = conn.execute("SELECT * FROM backtest_runs WHERE name = 'test-run'").fetchone()
+        assert row is not None
+        assert row["name"] == "test-run"
+        assert row["strategy_params"] == '{"max_trades": 15}'
+        assert row["completed_at"] is None
+
+    def test_snapshots_has_backtest_run_id_column(self) -> None:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        _create_schema(conn)
+
+        snapshot_id = insert_snapshot(conn, {
+            "snapshot_date": "2026-05-14",
+            "universe_size": 500,
+            "qualified_stocks": 42,
+            "trades_screened": 100,
+            "market_risk_elevated": False,
+            "vix_level": 18.0,
+            "spy_price": 520.0,
+        })
+
+        row = conn.execute(
+            "SELECT backtest_run_id FROM snapshots WHERE id = ?", (snapshot_id,)
+        ).fetchone()
+        assert row["backtest_run_id"] is None
+
+    def test_snapshot_with_backtest_run_id(self) -> None:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        _create_schema(conn)
+
+        conn.execute("""
+            INSERT INTO backtest_runs (name, started_at, date_range_start, date_range_end,
+                                       scan_frequency, strategy_params)
+            VALUES ('test-run', '2026-05-14T10:00:00', '2025-05-01', '2026-05-01',
+                    'weekly', '{}')
+        """)
+        conn.commit()
+        run_id = conn.execute("SELECT id FROM backtest_runs").fetchone()["id"]
+
+        conn.execute("""
+            INSERT INTO snapshots (snapshot_date, universe_size, qualified_stocks,
+                                   trades_screened, market_risk_elevated, vix_level,
+                                   spy_price, backtest_run_id)
+            VALUES ('2026-05-14', 500, 42, 100, 0, 18.0, 520.0, ?)
+        """, (run_id,))
+        conn.commit()
+
+        row = conn.execute("SELECT backtest_run_id FROM snapshots").fetchone()
+        assert row["backtest_run_id"] == run_id

--- a/tests/test_technicals.py
+++ b/tests/test_technicals.py
@@ -1,7 +1,6 @@
 """Tests for technical support/resistance calculation."""
 
 import pandas as pd
-import numpy as np
 
 from app.engine.technicals import _find_local_minima, _cluster_levels, find_support_level
 from tests.conftest import MockMarketDataProvider, make_stock
@@ -76,14 +75,14 @@ class TestFindSupportLevel:
         )
         hist = pd.DataFrame({
             "Open": lows,
-            "High": [l + 2 for l in lows],
+            "High": [low + 2 for low in lows],
             "Low": lows,
-            "Close": [l + 1 for l in lows],
+            "Close": [low + 1 for low in lows],
             "Volume": [1000000] * len(lows),
         })
 
         class PriceProvider(MockMarketDataProvider):
-            def get_price_history(self, symbol, period="3mo", interval="1d"):
+            def get_price_history(self, symbol, period="3mo", interval="1d", *, as_of=None):
                 return hist
 
         provider = PriceProvider({"TEST": make_stock()})

--- a/uv.lock
+++ b/uv.lock
@@ -451,6 +451,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "ruff" },
     { name = "uvicorn" },
     { name = "yfinance" },
 ]
@@ -473,6 +474,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "ruff", specifier = ">=0.15.12" },
     { name = "uvicorn", specifier = ">=0.41.0" },
     { name = "yfinance", specifier = ">=1.2.0" },
 ]
@@ -750,6 +752,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **AVClient**: HTTP client with 75 req/min sliding-window rate limiter, retry with exponential backoff (429/5xx/network), and SQLite cache integration via AVCache. Eight endpoint methods covering overview, balance sheet, price history, options chain, VIX, earnings, earnings calendar, and news sentiment.
- **AVCache**: SQLite-backed cache with generic key/payload/TTL table and typed options chain table. Stale-on-error fallback serves expired data when upstream fails. Supports `bypass_cache` escape hatch.
- **Thin adapters**: `AVMarketDataAdapter`, `AVOptionsAdapter`, `AVNewsAdapter` implementing existing ABCs — translate provider calls to AVClient with minimal logic.
- **`as_of` plumbing**: Every provider ABC method and engine function gained `as_of: date | None = None`. All hardcoded `date.today()` replaced with threaded value for backtest support.
- **Schema**: `backtest_runs` table + `backtest_run_id` FK on snapshots (prep for slice 3).
- **Backup extensions**: `restore_db_from_s3`, immortal `screener-latest.db` upload, prune protection for latest.

## Test plan

- [x] 149 tests pass (28 new + 121 existing)
- [x] Ruff clean
- [x] QA plan posted and executed on issue #17 (5/5 pass)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)