### PR TITLE
[#20] Backtest run selector + equity curve view

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -105,15 +105,25 @@ def get_unresolved_trades(
     return [dict(row) for row in rows]
 
 
-def get_summary_stats(conn: sqlite3.Connection) -> dict:
+def get_summary_stats(conn: sqlite3.Connection, *, backtest_run_id: int | None = None) -> dict:
     """Compute aggregate backtesting statistics from stored trades."""
-    counts = conn.execute("""
+    run_filter = ""
+    params: list = []
+    if backtest_run_id is not None:
+        run_filter = " AND s.backtest_run_id = ?"
+        params = [backtest_run_id]
+    else:
+        run_filter = " AND s.backtest_run_id IS NULL"
+
+    counts = conn.execute(f"""
         SELECT
             COUNT(*) AS total_tracked,
-            SUM(CASE WHEN outcome IS NOT NULL THEN 1 ELSE 0 END) AS total_resolved,
-            SUM(CASE WHEN outcome IS NULL THEN 1 ELSE 0 END) AS total_active
-        FROM snapshot_trades
-    """).fetchone()
+            SUM(CASE WHEN t.outcome IS NOT NULL THEN 1 ELSE 0 END) AS total_resolved,
+            SUM(CASE WHEN t.outcome IS NULL THEN 1 ELSE 0 END) AS total_active
+        FROM snapshot_trades t
+        JOIN snapshots s ON t.snapshot_id = s.id
+        WHERE 1=1{run_filter}
+    """, params).fetchone()
 
     total_tracked = counts["total_tracked"]
     total_resolved = counts["total_resolved"]
@@ -133,20 +143,22 @@ def get_summary_stats(conn: sqlite3.Connection) -> dict:
             "date_range_end": None,
         }
 
-    resolved_stats = conn.execute("""
+    resolved_stats = conn.execute(f"""
         SELECT
-            SUM(CASE WHEN outcome = 'OTM' THEN 1 ELSE 0 END) AS wins,
-            AVG(pnl_pct) AS avg_return_pct,
-            AVG(CASE WHEN outcome = 'OTM' THEN pnl_pct END) AS avg_win_pct,
-            AVG(CASE WHEN outcome = 'ITM' THEN pnl_pct END) AS avg_loss_pct
-        FROM snapshot_trades
-        WHERE outcome IS NOT NULL
-    """).fetchone()
+            SUM(CASE WHEN t.outcome = 'OTM' THEN 1 ELSE 0 END) AS wins,
+            AVG(t.pnl_pct) AS avg_return_pct,
+            AVG(CASE WHEN t.outcome = 'OTM' THEN t.pnl_pct END) AS avg_win_pct,
+            AVG(CASE WHEN t.outcome = 'ITM' THEN t.pnl_pct END) AS avg_loss_pct
+        FROM snapshot_trades t
+        JOIN snapshots s ON t.snapshot_id = s.id
+        WHERE t.outcome IS NOT NULL{run_filter}
+    """, params).fetchone()
 
-    date_range = conn.execute("""
-        SELECT MIN(snapshot_date) AS date_range_start, MAX(snapshot_date) AS date_range_end
-        FROM snapshots
-    """).fetchone()
+    date_range = conn.execute(f"""
+        SELECT MIN(s.snapshot_date) AS date_range_start, MAX(s.snapshot_date) AS date_range_end
+        FROM snapshots s
+        WHERE 1=1{run_filter}
+    """, params).fetchone()
 
     hit_rate = None
     avg_win_pct = resolved_stats["avg_win_pct"]
@@ -173,20 +185,68 @@ def get_summary_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
-def get_trades_by_status(conn: sqlite3.Connection, status: str) -> list[dict]:
+def get_trades_by_status(
+    conn: sqlite3.Connection, status: str, *, backtest_run_id: int | None = None
+) -> list[dict]:
     """Return trades filtered by status: 'active', 'resolved', or 'all'."""
     base = """
         SELECT t.*, s.snapshot_date
         FROM snapshot_trades t
         JOIN snapshots s ON t.snapshot_id = s.id
     """
-    if status == "active":
-        rows = conn.execute(base + " WHERE t.outcome IS NULL").fetchall()
-    elif status == "resolved":
-        rows = conn.execute(base + " WHERE t.outcome IS NOT NULL").fetchall()
+    conditions: list[str] = []
+    params: list = []
+
+    if backtest_run_id is not None:
+        conditions.append("s.backtest_run_id = ?")
+        params.append(backtest_run_id)
     else:
-        rows = conn.execute(base).fetchall()
+        conditions.append("s.backtest_run_id IS NULL")
+
+    if status == "active":
+        conditions.append("t.outcome IS NULL")
+    elif status == "resolved":
+        conditions.append("t.outcome IS NOT NULL")
+
+    where = " WHERE " + " AND ".join(conditions) if conditions else ""
+    rows = conn.execute(base + where, params).fetchall()
     return [dict(row) for row in rows]
+
+
+def get_equity_curve_data(
+    conn: sqlite3.Connection, *, backtest_run_id: int | None = None
+) -> list[dict]:
+    """Return cumulative P&L time series grouped by snapshot date."""
+    run_filter = ""
+    params: list = []
+    if backtest_run_id is not None:
+        run_filter = " AND s.backtest_run_id = ?"
+        params = [backtest_run_id]
+    else:
+        run_filter = " AND s.backtest_run_id IS NULL"
+
+    rows = conn.execute(f"""
+        SELECT
+            s.snapshot_date AS scan_date,
+            SUM(t.pnl_pct) AS day_pnl,
+            COUNT(t.id) AS trade_count
+        FROM snapshot_trades t
+        JOIN snapshots s ON t.snapshot_id = s.id
+        WHERE t.outcome IS NOT NULL{run_filter}
+        GROUP BY s.snapshot_date
+        ORDER BY s.snapshot_date
+    """, params).fetchall()
+
+    result = []
+    cumulative = 0.0
+    for row in rows:
+        cumulative += row["day_pnl"]
+        result.append({
+            "scan_date": row["scan_date"],
+            "cumulative_pnl_pct": cumulative,
+            "trade_count": row["trade_count"],
+        })
+    return result
 
 
 def _create_schema(conn: sqlite3.Connection) -> None:

--- a/app/server.py
+++ b/app/server.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
-from app.db import get_connection, get_summary_stats, get_trades_by_status
+from app.db import get_connection, get_equity_curve_data, get_summary_stats, get_trades_by_status
 from app.engine.market_risk import assess_market_risk
 from app.engine.pipeline import run_scan
 from app.engine.universe import filter_universe
@@ -190,27 +190,63 @@ def get_market_status() -> MarketRiskStatus:
 
 
 # ---------------------------------------------------------------------------
+# Backtest run endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/backtest/runs")
+def get_backtest_runs() -> list[dict]:
+    """Return all backtest runs sorted by started_at descending."""
+    conn = get_connection(settings.db_path)
+    try:
+        rows = conn.execute("""
+            SELECT
+                r.id, r.name, r.started_at, r.completed_at,
+                r.date_range_start, r.date_range_end,
+                COUNT(t.id) AS total_trades
+            FROM backtest_runs r
+            LEFT JOIN snapshots s ON s.backtest_run_id = r.id
+            LEFT JOIN snapshot_trades t ON t.snapshot_id = s.id
+            GROUP BY r.id
+            ORDER BY r.started_at DESC
+        """).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # Report endpoints — backtesting data
 # ---------------------------------------------------------------------------
 
 
+@app.get("/api/report/equity-curve")
+def get_equity_curve(backtest_run_id: int | None = None) -> list[dict]:
+    """Return cumulative P&L time series grouped by scan date."""
+    conn = get_connection(settings.db_path)
+    try:
+        return get_equity_curve_data(conn, backtest_run_id=backtest_run_id)
+    finally:
+        conn.close()
+
+
 @app.get("/api/report/summary", response_model=SummaryResponse)
-def get_report_summary() -> SummaryResponse:
+def get_report_summary(backtest_run_id: int | None = None) -> SummaryResponse:
     """Return aggregate backtesting statistics."""
     conn = get_connection(settings.db_path)
     try:
-        stats = get_summary_stats(conn)
+        stats = get_summary_stats(conn, backtest_run_id=backtest_run_id)
         return SummaryResponse(**stats)
     finally:
         conn.close()
 
 
 @app.get("/api/report/trades", response_model=TradesResponse)
-def get_report_trades(status: str = "all") -> TradesResponse:
+def get_report_trades(status: str = "all", backtest_run_id: int | None = None) -> TradesResponse:
     """Return trade list filtered by status with computed fields."""
     conn = get_connection(settings.db_path)
     try:
-        rows = get_trades_by_status(conn, status)
+        rows = get_trades_by_status(conn, status, backtest_run_id=backtest_run_id)
         today = date.today()
         trades = []
         for row in rows:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.14.0"
+        "react-router-dom": "^7.14.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -843,6 +844,42 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
@@ -1109,7 +1146,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -1504,6 +1546,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1539,7 +1644,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1554,6 +1659,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.1",
@@ -2216,6 +2327,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2303,8 +2423,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2343,6 +2584,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -2420,6 +2667,16 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2638,6 +2895,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2846,6 +3109,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2881,6 +3154,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -3695,9 +3977,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-router": {
       "version": "7.14.0",
@@ -3737,6 +4041,36 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3751,6 +4085,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3760,6 +4109,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3967,6 +4322,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4186,6 +4547,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.14.0"
+    "react-router-dom": "^7.14.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ScanResult, MarketRiskStatus, SummaryResponse, TradesResponse } from '../types'
+import type { ScanResult, MarketRiskStatus, SummaryResponse, TradesResponse, BacktestRun, EquityCurvePoint } from '../types'
 
 // In dev: empty string → Vite proxy handles /api → localhost:8000
 // In prod: VITE_API_URL points to the Railway backend (e.g. https://my-app.up.railway.app/api)
@@ -23,14 +23,34 @@ export async function fetchMarketStatus(): Promise<MarketRiskStatus> {
   return resp.json()
 }
 
-export async function fetchReportSummary(): Promise<SummaryResponse> {
-  const resp = await fetch(`${BASE}/report/summary`)
+export async function fetchBacktestRuns(): Promise<BacktestRun[]> {
+  const resp = await fetch(`${BASE}/backtest/runs`)
+  if (!resp.ok) throw new Error(`Failed to fetch backtest runs: ${resp.status}`)
+  return resp.json()
+}
+
+export async function fetchReportSummary(backtestRunId?: number | null): Promise<SummaryResponse> {
+  const params = new URLSearchParams()
+  if (backtestRunId != null) params.set('backtest_run_id', String(backtestRunId))
+  const qs = params.toString()
+  const resp = await fetch(`${BASE}/report/summary${qs ? '?' + qs : ''}`)
   if (!resp.ok) throw new Error(`Failed to fetch report summary: ${resp.status}`)
   return resp.json()
 }
 
-export async function fetchReportTrades(status: string = 'all'): Promise<TradesResponse> {
-  const resp = await fetch(`${BASE}/report/trades?status=${status}`)
+export async function fetchReportTrades(status: string = 'all', backtestRunId?: number | null): Promise<TradesResponse> {
+  const params = new URLSearchParams({ status })
+  if (backtestRunId != null) params.set('backtest_run_id', String(backtestRunId))
+  const resp = await fetch(`${BASE}/report/trades?${params.toString()}`)
   if (!resp.ok) throw new Error(`Failed to fetch report trades: ${resp.status}`)
+  return resp.json()
+}
+
+export async function fetchEquityCurve(backtestRunId?: number | null): Promise<EquityCurvePoint[]> {
+  const params = new URLSearchParams()
+  if (backtestRunId != null) params.set('backtest_run_id', String(backtestRunId))
+  const qs = params.toString()
+  const resp = await fetch(`${BASE}/report/equity-curve${qs ? '?' + qs : ''}`)
+  if (!resp.ok) throw new Error(`Failed to fetch equity curve: ${resp.status}`)
   return resp.json()
 }

--- a/frontend/src/components/BacktestRunSelector.tsx
+++ b/frontend/src/components/BacktestRunSelector.tsx
@@ -1,0 +1,27 @@
+import type { BacktestRun } from '../types'
+
+interface Props {
+  runs: BacktestRun[]
+  selectedRunId: number | null
+  onChange: (runId: number | null) => void
+}
+
+export default function BacktestRunSelector({ runs, selectedRunId, onChange }: Props) {
+  return (
+    <select
+      value={selectedRunId ?? ''}
+      onChange={(e) => {
+        const val = e.target.value
+        onChange(val === '' ? null : Number(val))
+      }}
+      className="bg-terminal-bg border border-terminal-border text-terminal-text text-sm rounded px-2 py-1"
+    >
+      <option value="">Live</option>
+      {runs.map((run) => (
+        <option key={run.id} value={run.id}>
+          {run.name}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/frontend/src/components/EquityCurve.tsx
+++ b/frontend/src/components/EquityCurve.tsx
@@ -1,0 +1,31 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import type { EquityCurvePoint } from '../types'
+
+interface Props {
+  data: EquityCurvePoint[]
+}
+
+export default function EquityCurve({ data }: Props) {
+  return (
+    <div className="h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+          <XAxis dataKey="scan_date" tick={{ fontSize: 11 }} stroke="#888" />
+          <YAxis tick={{ fontSize: 11 }} stroke="#888" tickFormatter={(v) => `${v.toFixed(1)}%`} />
+          <Tooltip
+            contentStyle={{ backgroundColor: '#1a1a2e', border: '1px solid #333' }}
+            formatter={(value: number) => [`${value.toFixed(2)}%`, 'Cumulative P&L']}
+          />
+          <Line
+            type="monotone"
+            dataKey="cumulative_pnl_pct"
+            stroke="#4ade80"
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -1,39 +1,54 @@
 import { useState, useEffect, useCallback } from 'react'
-import { fetchReportSummary, fetchReportTrades } from '../api/client'
+import { fetchBacktestRuns, fetchReportSummary, fetchReportTrades, fetchEquityCurve } from '../api/client'
 import ActiveTradesTable from '../components/ActiveTradesTable'
+import BacktestRunSelector from '../components/BacktestRunSelector'
+import EquityCurve from '../components/EquityCurve'
 import MethodologyPanel from '../components/MethodologyPanel'
 import ResolvedTradesTable from '../components/ResolvedTradesTable'
 import StatusFilter from '../components/StatusFilter'
 import SummaryCards from '../components/SummaryCards'
-import type { SummaryResponse, ReportTradeItem } from '../types'
+import type { SummaryResponse, ReportTradeItem, BacktestRun, EquityCurvePoint } from '../types'
 
 export default function ReportPage() {
   const [summary, setSummary] = useState<SummaryResponse | null>(null)
   const [trades, setTrades] = useState<ReportTradeItem[]>([])
   const [status, setStatus] = useState('all')
   const [loading, setLoading] = useState(true)
+  const [runs, setRuns] = useState<BacktestRun[]>([])
+  const [selectedRunId, setSelectedRunId] = useState<number | null>(null)
+  const [equityCurve, setEquityCurve] = useState<EquityCurvePoint[]>([])
 
-  const loadTrades = useCallback(async (s: string) => {
-    const t = await fetchReportTrades(s)
-    setTrades(t.trades)
+  const loadData = useCallback(async (s: string, runId: number | null) => {
+    const [summaryData, tradesData, curveData] = await Promise.all([
+      fetchReportSummary(runId),
+      fetchReportTrades(s, runId),
+      fetchEquityCurve(runId),
+    ])
+    setSummary(summaryData)
+    setTrades(tradesData.trades)
+    setEquityCurve(curveData)
   }, [])
 
   useEffect(() => {
     async function load() {
       setLoading(true)
-      const [s] = await Promise.all([
-        fetchReportSummary(),
-        loadTrades(status),
-      ])
-      setSummary(s)
+      const runsData = await fetchBacktestRuns()
+      setRuns(runsData)
+      await loadData(status, selectedRunId)
       setLoading(false)
     }
     load()
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const handleRunChange = async (runId: number | null) => {
+    setSelectedRunId(runId)
+    await loadData(status, runId)
+  }
+
   const handleStatusChange = async (newStatus: string) => {
     setStatus(newStatus)
-    await loadTrades(newStatus)
+    const tradesData = await fetchReportTrades(newStatus, selectedRunId)
+    setTrades(tradesData.trades)
   }
 
   if (loading) {
@@ -61,15 +76,25 @@ export default function ReportPage() {
   return (
     <div className="flex-1 px-4 py-4">
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-lg font-bold">Backtesting Report</h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-lg font-bold">Backtesting Report</h1>
+          <BacktestRunSelector runs={runs} selectedRunId={selectedRunId} onChange={handleRunChange} />
+        </div>
         <StatusFilter value={status} onChange={handleStatusChange} />
       </div>
 
       {summary && <SummaryCards summary={summary} />}
 
+      {equityCurve.length > 0 && (
+        <section className="mt-6">
+          <h2 className="text-sm font-bold text-terminal-muted mb-2">Equity Curve</h2>
+          <EquityCurve data={equityCurve} />
+        </section>
+      )}
+
       <section className="mt-6">
         <h2 className="text-sm font-bold text-terminal-muted mb-2">Active Trades</h2>
-        <ActiveTradesTable trades={activeTrades} onRefresh={() => loadTrades(status)} />
+        <ActiveTradesTable trades={activeTrades} onRefresh={() => handleStatusChange(status)} />
       </section>
 
       <section className="mt-6">

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -59,7 +59,7 @@ export default function ReportPage() {
     )
   }
 
-  if (summary && summary.total_tracked === 0) {
+  if (summary && summary.total_tracked === 0 && runs.length === 0) {
     return (
       <div className="flex-1 px-4 py-4">
         <h1 className="text-lg font-bold mb-4">Backtesting Report</h1>

--- a/frontend/src/test/BacktestRunSelector.test.tsx
+++ b/frontend/src/test/BacktestRunSelector.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BacktestRunSelector from '../components/BacktestRunSelector'
+
+const MOCK_RUNS = [
+  {
+    id: 2,
+    name: 'run-beta',
+    started_at: '2026-04-15T08:00:00+00:00',
+    completed_at: '2026-04-15T09:00:00+00:00',
+    date_range_start: '2025-07-01',
+    date_range_end: '2025-12-31',
+    total_trades: 15,
+  },
+  {
+    id: 1,
+    name: 'run-alpha',
+    started_at: '2026-03-01T10:00:00+00:00',
+    completed_at: '2026-03-01T11:00:00+00:00',
+    date_range_start: '2025-01-01',
+    date_range_end: '2025-06-30',
+    total_trades: 10,
+  },
+]
+
+describe('BacktestRunSelector', () => {
+  it('renders a Live option and all runs', async () => {
+    const onChange = vi.fn()
+    render(
+      <BacktestRunSelector runs={MOCK_RUNS} selectedRunId={null} onChange={onChange} />,
+    )
+
+    const select = screen.getByRole('combobox')
+    expect(select).toBeInTheDocument()
+
+    await userEvent.click(select)
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(3)
+    expect(options[0]).toHaveTextContent('Live')
+    expect(options[1]).toHaveTextContent('run-beta')
+    expect(options[2]).toHaveTextContent('run-alpha')
+  })
+
+  it('calls onChange with run id when a run is selected', async () => {
+    const onChange = vi.fn()
+    render(
+      <BacktestRunSelector runs={MOCK_RUNS} selectedRunId={null} onChange={onChange} />,
+    )
+
+    await userEvent.selectOptions(screen.getByRole('combobox'), '2')
+    expect(onChange).toHaveBeenCalledWith(2)
+  })
+
+  it('calls onChange with null when Live is selected', async () => {
+    const onChange = vi.fn()
+    render(
+      <BacktestRunSelector runs={MOCK_RUNS} selectedRunId={2} onChange={onChange} />,
+    )
+
+    await userEvent.selectOptions(screen.getByRole('combobox'), '')
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+})

--- a/frontend/src/test/EquityCurve.test.tsx
+++ b/frontend/src/test/EquityCurve.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react'
+import EquityCurve from '../components/EquityCurve'
+
+const MOCK_DATA = [
+  { scan_date: '2025-01-15', cumulative_pnl_pct: 1.5, trade_count: 1 },
+  { scan_date: '2025-02-15', cumulative_pnl_pct: 0.7, trade_count: 1 },
+  { scan_date: '2025-03-15', cumulative_pnl_pct: 2.3, trade_count: 2 },
+]
+
+describe('EquityCurve', () => {
+  it('renders without crashing with data', () => {
+    const { container } = render(<EquityCurve data={MOCK_DATA} />)
+    expect(container.querySelector('.recharts-responsive-container')).toBeInTheDocument()
+  })
+
+  it('renders without crashing with empty data', () => {
+    const { container } = render(<EquityCurve data={[]} />)
+    expect(container.querySelector('.recharts-responsive-container')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/ReportPage.test.tsx
+++ b/frontend/src/test/ReportPage.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../hooks/useTrades', () => ({
 }))
 
 vi.mock('../api/client', () => ({
+  fetchBacktestRuns: vi.fn().mockResolvedValue([]),
   fetchReportSummary: vi.fn().mockResolvedValue({
     total_tracked: 0, total_resolved: 0, total_active: 0,
     hit_rate: null, avg_return_pct: null, avg_win_pct: null,
@@ -16,6 +17,7 @@ vi.mock('../api/client', () => ({
     date_range_start: null, date_range_end: null,
   }),
   fetchReportTrades: vi.fn().mockResolvedValue({ trades: [] }),
+  fetchEquityCurve: vi.fn().mockResolvedValue([]),
 }))
 
 function renderApp(route = '/') {
@@ -183,8 +185,8 @@ describe('StatusFilter', () => {
     // Click "Active" filter
     await userEvent.click(screen.getByRole('button', { name: /^active$/i }))
 
-    // Should have re-fetched with status=active
-    expect(fetchReportTrades).toHaveBeenLastCalledWith('active')
+    // Should have re-fetched with status=active (and null run id for live)
+    expect(fetchReportTrades).toHaveBeenLastCalledWith('active', null)
   })
 })
 
@@ -256,5 +258,57 @@ describe('EmptyTables', () => {
 
     expect(await screen.findByText(/no active trades/i)).toBeInTheDocument()
     expect(screen.getByText(/no resolved trades/i)).toBeInTheDocument()
+  })
+})
+
+const MOCK_RUNS = [
+  {
+    id: 7,
+    name: 'weekly-jan',
+    started_at: '2026-04-15T08:00:00+00:00',
+    completed_at: '2026-04-15T09:00:00+00:00',
+    date_range_start: '2025-01-01',
+    date_range_end: '2025-06-30',
+    total_trades: 10,
+  },
+]
+
+describe('BacktestRunSelector integration', () => {
+  it('selecting a run re-fetches summary and trades with that run id', async () => {
+    const { fetchBacktestRuns, fetchReportSummary, fetchReportTrades, fetchEquityCurve } = await import('../api/client') as any
+    fetchBacktestRuns.mockResolvedValue(MOCK_RUNS)
+    fetchReportSummary.mockResolvedValue(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades.mockResolvedValue({ trades: [MOCK_ACTIVE_TRADE] })
+    fetchEquityCurve.mockResolvedValue([])
+
+    renderApp('/report')
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+
+    // Select a backtest run
+    await userEvent.selectOptions(screen.getByRole('combobox'), '7')
+
+    // Should re-fetch with backtest_run_id
+    expect(fetchReportSummary).toHaveBeenLastCalledWith(7)
+    expect(fetchReportTrades).toHaveBeenLastCalledWith('all', 7)
+    expect(fetchEquityCurve).toHaveBeenLastCalledWith(7)
+  })
+
+  it('selecting Live reverts to live data', async () => {
+    const { fetchBacktestRuns, fetchReportSummary, fetchReportTrades, fetchEquityCurve } = await import('../api/client') as any
+    fetchBacktestRuns.mockResolvedValue(MOCK_RUNS)
+    fetchReportSummary.mockResolvedValue(MOCK_SUMMARY_WITH_DATA)
+    fetchReportTrades.mockResolvedValue({ trades: [MOCK_ACTIVE_TRADE] })
+    fetchEquityCurve.mockResolvedValue([])
+
+    renderApp('/report')
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+
+    // Select a run first
+    await userEvent.selectOptions(screen.getByRole('combobox'), '7')
+    // Then switch back to Live
+    await userEvent.selectOptions(screen.getByRole('combobox'), '')
+
+    expect(fetchReportSummary).toHaveBeenLastCalledWith(null)
+    expect(fetchReportTrades).toHaveBeenLastCalledWith('all', null)
   })
 })

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -10,3 +10,10 @@ Object.defineProperty(globalThis, 'localStorage', {
     clear: () => { for (const k in store) delete store[k] },
   },
 })
+
+// ResizeObserver stub for recharts
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -72,6 +72,22 @@ export interface TradesResponse {
   trades: ReportTradeItem[]
 }
 
+export interface BacktestRun {
+  id: number
+  name: string
+  started_at: string
+  completed_at: string | null
+  date_range_start: string
+  date_range_end: string
+  total_trades: number
+}
+
+export interface EquityCurvePoint {
+  scan_date: string
+  cumulative_pnl_pct: number
+  trade_count: number
+}
+
 export interface MarketRiskStatus {
   vix_level: number
   vix_threshold: number

--- a/tests/test_report_api.py
+++ b/tests/test_report_api.py
@@ -81,7 +81,119 @@ def _seed_mixed_trades(conn):
             update_trade_outcome(conn, t["id"], "ITM", 195.0, -1.25)
 
 
+def _seed_backtest_runs(conn):
+    """Insert two backtest runs with different started_at times."""
+    conn.execute(
+        """INSERT INTO backtest_runs (name, started_at, completed_at, date_range_start, date_range_end, scan_frequency, strategy_params)
+           VALUES ('run-alpha', '2026-03-01T10:00:00+00:00', '2026-03-01T11:00:00+00:00', '2025-01-01', '2025-06-30', 'weekly', '{}')"""
+    )
+    conn.execute(
+        """INSERT INTO backtest_runs (name, started_at, completed_at, date_range_start, date_range_end, scan_frequency, strategy_params)
+           VALUES ('run-beta', '2026-04-15T08:00:00+00:00', '2026-04-15T09:00:00+00:00', '2025-07-01', '2025-12-31', 'weekly', '{}')"""
+    )
+    conn.commit()
+
+
+class TestBacktestRuns:
+    def test_returns_runs_sorted_by_started_at_desc(self, client, conn):
+        _seed_backtest_runs(conn)
+        resp = client.get("/api/backtest/runs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "run-beta"
+        assert data[1]["name"] == "run-alpha"
+        assert "id" in data[0]
+        assert "started_at" in data[0]
+        assert "total_trades" in data[0]
+
+
+    def test_returns_empty_list_when_no_runs(self, client):
+        resp = client.get("/api/backtest/runs")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+def _seed_run_with_trades(conn) -> int:
+    """Create a backtest run with 2 trades (1 resolved OTM, 1 active)."""
+    conn.execute(
+        """INSERT INTO backtest_runs (id, name, started_at, completed_at, date_range_start, date_range_end, scan_frequency, strategy_params)
+           VALUES (99, 'test-run', '2026-03-01T10:00:00+00:00', '2026-03-01T11:00:00+00:00', '2025-01-01', '2025-06-30', 'weekly', '{}')"""
+    )
+    conn.commit()
+    snap_id = insert_snapshot(conn, {**SAMPLE_SNAPSHOT, "backtest_run_id": 99})
+    resolved = {**SAMPLE_TRADE, "expiry": "2026-04-01"}
+    active = {**SAMPLE_TRADE, "rank": 2, "symbol": "MSFT", "expiry": "2026-04-25"}
+    insert_trades(conn, snap_id, [resolved, active])
+    trade_id = conn.execute(
+        "SELECT id FROM snapshot_trades WHERE symbol = 'AAPL' AND snapshot_id = ?", (snap_id,)
+    ).fetchone()["id"]
+    update_trade_outcome(conn, trade_id, "OTM", 210.0, 1.25)
+    return 99
+
+
+def _seed_run_with_equity_data(conn) -> int:
+    """Create a run with resolved trades across multiple snapshot dates for equity curve."""
+    conn.execute(
+        """INSERT INTO backtest_runs (id, name, started_at, completed_at, date_range_start, date_range_end, scan_frequency, strategy_params)
+           VALUES (50, 'equity-run', '2026-02-01T10:00:00+00:00', '2026-02-01T11:00:00+00:00', '2025-01-01', '2025-03-31', 'weekly', '{}')"""
+    )
+    conn.commit()
+    # Two snapshots on different dates
+    snap1 = insert_snapshot(conn, {**SAMPLE_SNAPSHOT, "snapshot_date": "2025-01-15", "backtest_run_id": 50})
+    snap2 = insert_snapshot(conn, {**SAMPLE_SNAPSHOT, "snapshot_date": "2025-02-15", "backtest_run_id": 50})
+    trade1 = {**SAMPLE_TRADE, "expiry": "2025-01-30"}
+    trade2 = {**SAMPLE_TRADE, "rank": 2, "symbol": "MSFT", "expiry": "2025-02-28"}
+    insert_trades(conn, snap1, [trade1])
+    insert_trades(conn, snap2, [trade2])
+    # Resolve both
+    t1_id = conn.execute("SELECT id FROM snapshot_trades WHERE snapshot_id = ?", (snap1,)).fetchone()["id"]
+    t2_id = conn.execute("SELECT id FROM snapshot_trades WHERE snapshot_id = ?", (snap2,)).fetchone()["id"]
+    update_trade_outcome(conn, t1_id, "OTM", 210.0, 1.5)
+    update_trade_outcome(conn, t2_id, "ITM", 195.0, -0.8)
+    return 50
+
+
+class TestEquityCurve:
+    def test_returns_cumulative_pnl_for_run(self, client, conn):
+        run_id = _seed_run_with_equity_data(conn)
+        resp = client.get(f"/api/report/equity-curve?backtest_run_id={run_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["scan_date"] == "2025-01-15"
+        assert data[0]["cumulative_pnl_pct"] == pytest.approx(1.5)
+        assert data[0]["trade_count"] == 1
+        assert data[1]["scan_date"] == "2025-02-15"
+        assert data[1]["cumulative_pnl_pct"] == pytest.approx(0.7)  # 1.5 + (-0.8)
+        assert data[1]["trade_count"] == 1
+
+
+    def test_returns_empty_when_no_resolved_trades(self, client, conn):
+        resp = client.get("/api/report/equity-curve?backtest_run_id=999")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
 class TestReportSummary:
+    def test_summary_filters_by_backtest_run_id(self, client, conn):
+        _seed_mixed_trades(conn)  # live trades
+        run_id = _seed_run_with_trades(conn)  # backtest run trades
+        resp = client.get(f"/api/report/summary?backtest_run_id={run_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_tracked"] == 2
+        assert data["total_resolved"] == 1
+        assert data["total_active"] == 1
+
+    def test_summary_excludes_backtest_data_when_no_run_id(self, client, conn):
+        _seed_mixed_trades(conn)  # 3 live trades
+        _seed_run_with_trades(conn)  # 2 backtest trades — should NOT appear
+        resp = client.get("/api/report/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_tracked"] == 3
+
     def test_summary_with_data(self, client, conn):
         _seed_mixed_trades(conn)
         resp = client.get("/api/report/summary")
@@ -107,6 +219,23 @@ class TestReportSummary:
 
 
 class TestReportTrades:
+    def test_trades_filters_by_backtest_run_id(self, client, conn):
+        _seed_mixed_trades(conn)  # 3 live trades
+        run_id = _seed_run_with_trades(conn)  # 2 backtest trades
+        resp = client.get(f"/api/report/trades?backtest_run_id={run_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["trades"]) == 2
+        symbols = {t["symbol"] for t in data["trades"]}
+        assert symbols == {"AAPL", "MSFT"}
+
+    def test_trades_excludes_backtest_data_when_no_run_id(self, client, conn):
+        _seed_mixed_trades(conn)  # 3 live trades
+        _seed_run_with_trades(conn)  # 2 backtest trades — should NOT appear
+        resp = client.get("/api/report/trades")
+        assert resp.status_code == 200
+        assert len(resp.json()["trades"]) == 3
+
     def test_filter_active(self, client, conn):
         _seed_mixed_trades(conn)
         resp = client.get("/api/report/trades?status=active")


### PR DESCRIPTION
## Summary
- Add `GET /api/backtest/runs` endpoint returning runs sorted by `started_at` desc
- Add `GET /api/report/equity-curve` endpoint with cumulative P&L time series
- Existing `/api/report/summary` and `/api/report/trades` now accept optional `?backtest_run_id` filter (null/omitted = live snapshots only)
- New `BacktestRunSelector` dropdown component with "Live" default option
- New `EquityCurve` line chart component using recharts
- `ReportPage` orchestrates `selectedRunId` state, re-fetching all data on selection change

Closes #20

## Test plan
- [x] Backend: 17 integration tests (in-memory SQLite) covering all new/modified endpoints
- [x] Frontend: 22 tests covering BacktestRunSelector, EquityCurve, and ReportPage integration
- [ ] Manual: run a backtest via CLI, open report tab, verify dropdown lists run, selecting updates cards/tables/chart, switching to Live reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)