### PR TITLE
fix(#20): Recharts v3 Tooltip formatter type error

### DIFF
--- a/frontend/src/components/EquityCurve.tsx
+++ b/frontend/src/components/EquityCurve.tsx
@@ -15,7 +15,7 @@ export default function EquityCurve({ data }: Props) {
           <YAxis tick={{ fontSize: 11 }} stroke="#888" tickFormatter={(v) => `${v.toFixed(1)}%`} />
           <Tooltip
             contentStyle={{ backgroundColor: '#1a1a2e', border: '1px solid #333' }}
-            formatter={(value: number) => [`${value.toFixed(2)}%`, 'Cumulative P&L']}
+            formatter={(value) => [`${Number(value ?? 0).toFixed(2)}%`, 'Cumulative P&L']}
           />
           <Line
             type="monotone"


### PR DESCRIPTION
## Summary
- Drops explicit `value: number` type annotation on the Recharts `<Tooltip>` formatter callback — Recharts v3 `ValueType` includes `string | number | ReadonlyArray<...> | undefined`, so the narrow annotation breaks `tsc`
- Uses `Number(value ?? 0)` for safe runtime coercion

## Test plan
- [ ] `cd frontend && npx tsc -b` passes cleanly
- [ ] Vercel build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)